### PR TITLE
DNM: Drag & Drop creatures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,16 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/hoist-non-react-statics": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
+      "integrity": "sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "@types/node": {
       "version": "11.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.4.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -368,6 +368,11 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1251,6 +1256,16 @@
         "bn.js": "^4.1.0",
         "miller-rabin": "^4.0.0",
         "randombytes": "^2.0.0"
+      }
+    },
+    "dnd-core": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-7.4.4.tgz",
+      "integrity": "sha512-xR8SINDCJG9AmKSjXUMJ1PEl8ih1+xSHH8x4DgBtzScXnEtpCnV1ibDZNV0uyps9VgkXTTbYYzJdF04y0v0e3Q==",
+      "requires": {
+        "asap": "^2.0.6",
+        "invariant": "^2.2.4",
+        "redux": "^4.0.1"
       }
     },
     "dns-equal": {
@@ -2539,6 +2554,14 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "hoist-non-react-statics": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "requires": {
+        "react-is": "^16.7.0"
+      }
+    },
     "homedir-polyfill": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
@@ -2707,6 +2730,14 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
       "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
       "dev": true
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
     },
     "invert-kv": {
       "version": "2.0.0",
@@ -3895,6 +3926,17 @@
         "scheduler": "^0.13.6"
       }
     },
+    "react-dnd": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/react-dnd/-/react-dnd-7.4.5.tgz",
+      "integrity": "sha512-/689FECqmfNxHZJymC0Ge0Vt5A2oxXwcpVpFjM7O21ifzSh3YtZl83rre6Cosdc4Sx9ucrMq3sRxKMH9p/ekCg==",
+      "requires": {
+        "dnd-core": "^7.4.4",
+        "hoist-non-react-statics": "^3.3.0",
+        "invariant": "^2.1.0",
+        "shallowequal": "^1.1.0"
+      }
+    },
     "react-dom": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
@@ -3935,6 +3977,15 @@
         "graceful-fs": "^4.1.11",
         "micromatch": "^3.1.10",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "redux": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "symbol-observable": "^1.2.0"
       }
     },
     "regex-not": {
@@ -4214,6 +4265,11 @@
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4657,6 +4713,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "symbol-observable": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ=="
     },
     "tapable": {
       "version": "1.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3947,6 +3947,14 @@
         "shallowequal": "^1.1.0"
       }
     },
+    "react-dnd-touch-backend": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/react-dnd-touch-backend/-/react-dnd-touch-backend-0.8.1.tgz",
+      "integrity": "sha512-pjy8QTvphM2vSua+e7eUUexPmPKyaWpXvf1U0kWBhMtWTRQGlaqqu4O3BfRKy4PI58OqmAh+YWv9RfIUPer9ug==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
+    },
     "react-dom": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "react": "^16.8.6",
     "react-dnd": "^7.4.5",
+    "react-dnd-touch-backend": "^0.8.1",
     "react-dom": "^16.8.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "homepage": "https://github.com/kjirou/tower-offense-7x7#readme",
   "private": true,
   "devDependencies": {
+    "@types/hoist-non-react-statics": "^3.3.1",
     "@types/node": "^11.13.4",
     "@types/react": "^16.8.13",
     "@types/react-dom": "^16.8.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "react": "^16.8.6",
+    "react-dnd": "^7.4.5",
     "react-dom": "^16.8.6"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,18 @@
 import * as React from 'react';
+import {DragDropContext} from 'react-dnd';
+
+const TouchBackend = require('react-dnd-touch-backend').default;
 
 import {Root} from './components/Root';
 import {mapStateToProps} from './map-state-to-props';
 import {ApplicationState} from './state-manager/application';
 
-export function App(props: {initialState: ApplicationState}): JSX.Element {
+function App_(props: {initialState: ApplicationState}): JSX.Element {
   const [state, setState] = React.useState(props.initialState);
 
   const rootProps = mapStateToProps(state, setState);
 
   return <Root {...rootProps} />;
 }
+
+export const App = DragDropContext(TouchBackend)(App_);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,4 +15,4 @@ function App_(props: {initialState: ApplicationState}): JSX.Element {
   return <Root {...rootProps} />;
 }
 
-export const App = DragDropContext(TouchBackend)(App_);
+export const App = DragDropContext(TouchBackend({ enableMouseEvents: true }))(App_);

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -1,9 +1,19 @@
 import * as React from 'react';
+import {
+  DragSource,
+} from 'react-dnd';
 
 import {flattenMatrix} from '../../utils';
 
 type CreatureOnSquareProps = {
   image: string,
+};
+
+type DraggableCreatureOnSquareProps = {
+  // TODO: Although react-dnd exports types, there was no documentation on how to use it.
+  connectDragSource: (element: JSX.Element) => any,
+  image: CreatureOnSquareProps['image'],
+  isDragging: boolean,
 };
 
 type BattleFieldSquareProps = {
@@ -58,6 +68,44 @@ function CreatureOnSquare(props: CreatureOnSquareProps): JSX.Element {
 
   return <div style={style}>{props.image}</div>
 }
+
+function DraggableCreatureOnSquare(props: DraggableCreatureOnSquareProps): JSX.Element {
+  const style = {
+    position: 'absolute',
+    top: '0',
+    left: '0',
+    width: '48px',
+    height: '48px',
+  };
+
+  const creatureOnSquareProps = {
+    image: props.image,
+  };
+
+  // NOTE: The div wrapping is needed against the following react-dnd's error.
+  //       "Only native element nodes can now be passed to React DnD connectors."
+  return props.connectDragSource(
+    <div style={style}>
+      <CreatureOnSquare {...creatureOnSquareProps} />
+    </div>
+  );
+}
+
+const DraggableCreatureOnSquareForBarrack = DragSource(
+  'DraggableCreatureOnSquareForBarrack',
+  {
+    beginDrag: props => {
+      console.log(props);  // TODO: Delete it
+      return props;
+    },
+  },
+  (connect, monitor) => {
+    return {
+      connectDragSource: connect.dragSource(),
+      isDragging: monitor.isDragging(),
+    };
+  }
+)(DraggableCreatureOnSquare);
 
 function BattleFieldSquare(props: BattleFieldSquareProps): JSX.Element {
   const style = {
@@ -126,7 +174,7 @@ function BarrackSquare(props: BarrackSquareProps): JSX.Element {
   return (
     <div style={style}>
     {
-      props.creature ? <CreatureOnSquare {...props.creature} /> : undefined
+      props.creature ? <DraggableCreatureOnSquareForBarrack {...props.creature} /> : undefined
     }
     </div>
   );

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {
+  DragLayer,
   DragSource,
 } from 'react-dnd';
 
@@ -77,8 +78,9 @@ function DraggableCreatureOnSquare(props: DraggableCreatureOnSquareProps): JSX.E
     width: '48px',
     height: '48px',
   };
+  console.log('isDragging:', props.isDragging);
 
-  const creatureOnSquareProps = {
+  const creatureOnSquareProps: CreatureOnSquareProps = {
     image: props.image,
   };
 
@@ -95,13 +97,13 @@ const DraggableCreatureOnSquareForBarrack = DragSource(
   'DraggableCreatureOnSquareForBarrack',
   {
     beginDrag: props => {
-      console.log(props);  // TODO: Delete it
       return props;
     },
   },
   (connect, monitor) => {
     return {
       connectDragSource: connect.dragSource(),
+      connectDragPreview: connect.dragPreview(),
       isDragging: monitor.isDragging(),
     };
   }
@@ -202,6 +204,31 @@ function Barrack(props: BarrackProps): JSX.Element {
   );
 }
 
+function CreatureDragLayer(): any {
+  function collect(monitor: any) {
+    return {
+      isDragging: monitor.isDragging(),
+    };
+  }
+
+  function DragPreview(props: {isDragging: boolean}): JSX.Element {
+    const style = {
+    };
+
+    if (!props.isDragging) {
+      return <div />;
+    }
+
+    return (
+      <div style={style}>
+        Dragging...
+      </div>
+    );
+  }
+
+  return DragLayer(collect)(DragPreview);
+}
+
 export function BattlePage(props: BattlePageProps): JSX.Element {
   const style = {
     position: 'relative',
@@ -216,6 +243,7 @@ export function BattlePage(props: BattlePageProps): JSX.Element {
       <BattleFieldBoard board={props.battleFieldBoard} />
       <SquareMonitor />
       <Barrack board={props.barrackBoard} />
+      <CreatureDragLayer />
     </div>
   );
 }


### PR DESCRIPTION
react-dnd で Drag & Drop させようとしたが、コスパに見合わなそうなのでメモして保留。


## 要件

- 兵舎から戦場へユニットをドラッグ＆ドロップできる。
  - 可能。
- 戦場から兵舎へユニットをドラッグ＆ドロップできる。
  - 可能。
- ユニットをドラッグ中には、ドラッグ中のプレビューを自由にカスタマイズできる。
  - DragLayer で可能そう。
- ドラッグとドロップの反応を調整できる。
  - どちらも早めへ調整できないと、逆にストレスになる。
  - 未調査。


## ライブラリについての所感
### 🙆 良かった点

- 広いユースケースに対応しており、上記の要件は満たせそう。
- TypeScript で書かれており、.d.ts も配布されている。

### 🙅 悪かった点

- ライブラリが巨大な一方で、部分的に抑えて使うことができない。
  - 全部 react-dnd に従うか使わないかの二択である。
  - 個人的には、画一的なフック処理が欲しかったのではなく、D&D イベントロジックが欲しかっただけ。ドラッグ中の要素の表現などは、表現の仕方でどうにでもなるのと量もないので、生 DOM でも良かった。
  - また、その巨大なライブラリで、プロジェクト側のルートコンポーネントをラップする必要があり、バグが副作用が出た時に怖い。
- モバイル用の touch イベントは公式は非対応である。
  - ただし、Yahoo 製のライブラリがあるので https://github.com/yahoo/react-dnd-touch-backend この点は影響少なそう。
- .d.ts はユーザー用にサポートはされておらず、例えばドキュメントなどはない。使う場合はソースを読む必要がある。
  - 少し読んだだけではわからないところもあり、any で回避した場所が増えた。またその逃げた実質的にも影響がある場所だった。例えば、一部の React コンポーネントに渡す Props が不整合を起こしててもわからなくなる。
- Hooks 用の API が未整備。現在も一応あるけど experimental である。
- 個人的な感想だけど、何度使って見ても API を忘れる。

### 🐱 使えるかもしれない状況

- PC ブラウザのみに対応すれば良い場合。
  - HTML5 の D&D の Preview 機能とリンクできるので、要件次第だが一手間楽になる。
- TypeScript ではなく JavaScript である。もしくは本体が TS 正式サポート。
  - 型を調べるのが大変だった。


## react-dnd を使わない場合はどうする？

- React だとこれ一択に見えてて、いい案はない。
- スマホ用の D&D のロジックだけ欲しければ、 https://github.com/yahoo/react-dnd-touch-backend を読み解けば取得できそう。