### PR TITLE
Turn transition

### DIFF
--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -129,7 +129,7 @@ describe('utils', function() {
       })
     })
 
-    describe('a=CardsOnYourHandPosition, b=CardsOnYourHandPosition', function() {
+    describe('a=CardOnPlayersHandPosition, b=CardOnPlayersHandPosition', function() {
       it('can return true if args are equal', function() {
         assert.strictEqual(
           areGlobalPositionsEqual(
@@ -163,7 +163,7 @@ describe('utils', function() {
       })
     })
 
-    describe('a=BattleFieldMatrixPosition, b=CardsOnYourHandPosition', function() {
+    describe('a=BattleFieldMatrixPosition, b=CardOnPlayersHandPosition', function() {
       it('can return false', function() {
         assert.strictEqual(
           areGlobalPositionsEqual(

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -134,11 +134,11 @@ describe('utils', function() {
         assert.strictEqual(
           areGlobalPositionsEqual(
             {
-              globalPlacementId: 'cardsOnYourHand',
+              globalPlacementId: 'cardsOnPlayersHand',
               creatureId: 'foo',
             },
             {
-              globalPlacementId: 'cardsOnYourHand',
+              globalPlacementId: 'cardsOnPlayersHand',
               creatureId: 'foo',
             }
           ),
@@ -150,11 +150,11 @@ describe('utils', function() {
         assert.strictEqual(
           areGlobalPositionsEqual(
             {
-              globalPlacementId: 'cardsOnYourHand',
+              globalPlacementId: 'cardsOnPlayersHand',
               creatureId: 'foo',
             },
             {
-              globalPlacementId: 'cardsOnYourHand',
+              globalPlacementId: 'cardsOnPlayersHand',
               creatureId: 'bar',
             }
           ),
@@ -168,7 +168,7 @@ describe('utils', function() {
         assert.strictEqual(
           areGlobalPositionsEqual(
             {
-              globalPlacementId: 'cardsOnYourHand',
+              globalPlacementId: 'cardsOnPlayersHand',
               creatureId: 'foo',
             },
             {
@@ -354,7 +354,7 @@ describe('utils', function() {
       assert.strictEqual(
         findCardUnderCursor(cards, {
           globalPosition: {
-            globalPlacementId: 'cardsOnYourHand',
+            globalPlacementId: 'cardsOnPlayersHand',
             creatureId: 'b',
           },
         }),
@@ -372,7 +372,7 @@ describe('utils', function() {
       assert.strictEqual(
         findCardUnderCursor(cards, {
           globalPosition: {
-            globalPlacementId: 'cardsOnYourHand',
+            globalPlacementId: 'cardsOnPlayersHand',
             creatureId: 'b',
           },
         }),

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -248,6 +248,7 @@ const CardsOnYourHand: React.FC<CardsOnYourHandProps> = (props) => {
 
 type FooterProps = {
   handleClickNextButton: () => void,
+  showNextTurnButton: boolean,
 }
 
 const Footer: React.FC<FooterProps> = (props) => {
@@ -259,6 +260,15 @@ const Footer: React.FC<FooterProps> = (props) => {
     justifyContent: 'space-between',
     alignItems: 'center',
     backgroundColor: 'aqua',
+  }
+
+  const rightSideButtonStyle = {
+    width: '136px',
+    height: '100%',
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'lime',
   }
 
   return (
@@ -273,7 +283,7 @@ const Footer: React.FC<FooterProps> = (props) => {
       }}>
         <div style={{
           fontSize: '24px',
-        }}>Back</div>
+        }}>Rollback</div>
       </div>
       <div style={{
         width: '72px',
@@ -286,23 +296,28 @@ const Footer: React.FC<FooterProps> = (props) => {
       }}>
         <div>5</div>
       </div>
-      <div
-        style={{
-          width: '136px',
-          height: '100%',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          backgroundColor: 'lime',
-        }}
-        onClick={props.handleClickNextButton}
-      >
-        <div
-          style={{
-            fontSize: '24px',
-          }}
-        >Next</div>
-      </div>
+      {
+        props.showNextTurnButton
+        ? <div
+          style={rightSideButtonStyle}
+        >
+          <div
+            style={{
+              fontSize: '24px',
+            }}
+          >Next</div>
+        </div>
+        : <div
+          style={rightSideButtonStyle}
+          onClick={props.handleClickNextButton}
+        >
+          <div
+            style={{
+              fontSize: '24px',
+            }}
+          >Battle</div>
+        </div>
+      }
     </div>
   )
 }
@@ -312,6 +327,7 @@ export type Props = {
   cardsOnYourHand: CardsOnYourHandProps,
   handleClickNextButton: FooterProps['handleClickNextButton'],
   turnNumber: MetaInformationBarProps['turnNumber'],
+  showNextTurnButton: FooterProps['showNextTurnButton'],
 }
 
 export const BattlePage: React.FC<Props> = (props) => {
@@ -330,6 +346,7 @@ export const BattlePage: React.FC<Props> = (props) => {
       <CardsOnYourHand {...props.cardsOnYourHand} />
       <Footer
         handleClickNextButton={props.handleClickNextButton}
+        showNextTurnButton={props.showNextTurnButton}
       />
     </div>
   )

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -247,7 +247,8 @@ const CardsOnYourHand: React.FC<CardsOnYourHandProps> = (props) => {
 }
 
 type FooterProps = {
-  handleClickNextButton: () => void,
+  handleClickBattleButton: () => void,
+  handleClickNextTurnButton: () => void,
   showNextTurnButton: boolean,
 }
 
@@ -300,6 +301,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         props.showNextTurnButton
         ? <div
           style={rightSideButtonStyle}
+          onClick={props.handleClickNextTurnButton}
         >
           <div
             style={{
@@ -309,7 +311,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         </div>
         : <div
           style={rightSideButtonStyle}
-          onClick={props.handleClickNextButton}
+          onClick={props.handleClickBattleButton}
         >
           <div
             style={{
@@ -325,7 +327,8 @@ const Footer: React.FC<FooterProps> = (props) => {
 export type Props = {
   battleFieldBoard: BattleFieldSquareProps[][],
   cardsOnYourHand: CardsOnYourHandProps,
-  handleClickNextButton: FooterProps['handleClickNextButton'],
+  handleClickBattleButton: FooterProps['handleClickBattleButton'],
+  handleClickNextTurnButton: FooterProps['handleClickNextTurnButton'],
   turnNumber: MetaInformationBarProps['turnNumber'],
   showNextTurnButton: FooterProps['showNextTurnButton'],
 }
@@ -345,7 +348,8 @@ export const BattlePage: React.FC<Props> = (props) => {
       <SquareMonitor />
       <CardsOnYourHand {...props.cardsOnYourHand} />
       <Footer
-        handleClickNextButton={props.handleClickNextButton}
+        handleClickBattleButton={props.handleClickBattleButton}
+        handleClickNextTurnButton={props.handleClickNextTurnButton}
         showNextTurnButton={props.showNextTurnButton}
       />
     </div>

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -301,7 +301,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         props.showNextTurnButton
         ? <div
           style={rightSideButtonStyle}
-          onClick={props.handleTouchNextTurnButton}
+          onTouchStart={props.handleTouchNextTurnButton}
         >
           <div
             style={{
@@ -311,7 +311,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         </div>
         : <div
           style={rightSideButtonStyle}
-          onClick={props.handleTouchBattleButton}
+          onTouchStart={props.handleTouchBattleButton}
         >
           <div
             style={{

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -311,6 +311,7 @@ export type Props = {
   battleFieldBoard: BattleFieldSquareProps[][],
   cardsOnYourHand: CardsOnYourHandProps,
   handleClickNextButton: FooterProps['handleClickNextButton'],
+  turnNumber: MetaInformationBarProps['turnNumber'],
 }
 
 export const BattlePage: React.FC<Props> = (props) => {
@@ -323,7 +324,7 @@ export const BattlePage: React.FC<Props> = (props) => {
 
   return (
     <div style={style}>
-      <MetaInformationBar turnNumber={99} />
+      <MetaInformationBar turnNumber={props.turnNumber} />
       <BattleFieldBoard board={props.battleFieldBoard} />
       <SquareMonitor />
       <CardsOnYourHand {...props.cardsOnYourHand} />

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -5,16 +5,33 @@ import {
   flattenMatrix,
 } from '../../utils'
 
-const MetaInformationBar: React.FC<{}> = () => {
+type MetaInformationBarProps = {
+  turnNumber: number,
+}
+
+const MetaInformationBar: React.FC<MetaInformationBarProps> = (props) => {
   const style = {
     position: 'relative',
+    display: 'flex',
+    justifyContent: 'flex-start',
     width: '360px',
     height: '48px',
     backgroundColor: 'yellow',
   }
 
   return (
-    <div style={style}>MetaInformationBar!</div>
+    <div style={style}>
+      <div
+        style={{
+          width: '48px',
+          height: '48px',
+          lineHeight: '48px',
+          fontSize: '24px',
+          textAlign: 'center',
+          backgroundColor: 'silver',
+        }}
+      >{props.turnNumber}</div>
+    </div>
   )
 }
 
@@ -306,7 +323,7 @@ export const BattlePage: React.FC<Props> = (props) => {
 
   return (
     <div style={style}>
-      <MetaInformationBar />
+      <MetaInformationBar turnNumber={99} />
       <BattleFieldBoard board={props.battleFieldBoard} />
       <SquareMonitor />
       <CardsOnYourHand {...props.cardsOnYourHand} />

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -214,12 +214,12 @@ const Card: React.FC<CardProps> = (props) => {
   )
 }
 
-type CardsOnYourHandProps = {
+type CardsOnPlayersHandProps = {
   // 0 to 5 cards.
   cards: CardProps[],
 }
 
-const CardsOnYourHand: React.FC<CardsOnYourHandProps> = (props) => {
+const CardsOnPlayersHand: React.FC<CardsOnPlayersHandProps> = (props) => {
   const style = {
     display: 'flex',
     width: '360px',
@@ -326,7 +326,7 @@ const Footer: React.FC<FooterProps> = (props) => {
 
 export type Props = {
   battleFieldBoard: BattleFieldSquareProps[][],
-  cardsOnYourHand: CardsOnYourHandProps,
+  cardsOnPlayersHand: CardsOnPlayersHandProps,
   handleTouchBattleButton: FooterProps['handleTouchBattleButton'],
   handleTouchNextTurnButton: FooterProps['handleTouchNextTurnButton'],
   turnNumber: MetaInformationBarProps['turnNumber'],
@@ -346,7 +346,7 @@ export const BattlePage: React.FC<Props> = (props) => {
       <MetaInformationBar turnNumber={props.turnNumber} />
       <BattleFieldBoard board={props.battleFieldBoard} />
       <SquareMonitor />
-      <CardsOnYourHand {...props.cardsOnYourHand} />
+      <CardsOnPlayersHand {...props.cardsOnPlayersHand} />
       <Footer
         handleTouchBattleButton={props.handleTouchBattleButton}
         handleTouchNextTurnButton={props.handleTouchNextTurnButton}

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -247,8 +247,8 @@ const CardsOnYourHand: React.FC<CardsOnYourHandProps> = (props) => {
 }
 
 type FooterProps = {
-  handleClickBattleButton: () => void,
-  handleClickNextTurnButton: () => void,
+  handleTouchBattleButton: () => void,
+  handleTouchNextTurnButton: () => void,
   showNextTurnButton: boolean,
 }
 
@@ -301,7 +301,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         props.showNextTurnButton
         ? <div
           style={rightSideButtonStyle}
-          onClick={props.handleClickNextTurnButton}
+          onClick={props.handleTouchNextTurnButton}
         >
           <div
             style={{
@@ -311,7 +311,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         </div>
         : <div
           style={rightSideButtonStyle}
-          onClick={props.handleClickBattleButton}
+          onClick={props.handleTouchBattleButton}
         >
           <div
             style={{
@@ -327,8 +327,8 @@ const Footer: React.FC<FooterProps> = (props) => {
 export type Props = {
   battleFieldBoard: BattleFieldSquareProps[][],
   cardsOnYourHand: CardsOnYourHandProps,
-  handleClickBattleButton: FooterProps['handleClickBattleButton'],
-  handleClickNextTurnButton: FooterProps['handleClickNextTurnButton'],
+  handleTouchBattleButton: FooterProps['handleTouchBattleButton'],
+  handleTouchNextTurnButton: FooterProps['handleTouchNextTurnButton'],
   turnNumber: MetaInformationBarProps['turnNumber'],
   showNextTurnButton: FooterProps['showNextTurnButton'],
 }
@@ -348,8 +348,8 @@ export const BattlePage: React.FC<Props> = (props) => {
       <SquareMonitor />
       <CardsOnYourHand {...props.cardsOnYourHand} />
       <Footer
-        handleClickBattleButton={props.handleClickBattleButton}
-        handleClickNextTurnButton={props.handleClickNextTurnButton}
+        handleTouchBattleButton={props.handleTouchBattleButton}
+        handleTouchNextTurnButton={props.handleTouchNextTurnButton}
         showNextTurnButton={props.showNextTurnButton}
       />
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ function createInitialGame(): Game {
       {creatureId: 'ally-7'},
     ],
     cursor: undefined,
+    turnNumber: 1,
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   Card,
   Creature,
   Game,
+  MAX_NUMBER_OF_PLAYERS_HAND,
   Party,
   SkillCategoryId,
   createBattleFieldMatrix,
@@ -114,14 +115,14 @@ function createInitialGame(): Game {
     battleFieldMatrix,
     cards: dummyAllCards,
     cardsOnYourHand: dummyAllCards
-      .slice(0, 5)
+      .slice(0, MAX_NUMBER_OF_PLAYERS_HAND)
       .map((card) => {
         return {
           creatureId: card.creatureId,
         }
       }),
     cardsInDeck: dummyAllCards
-      .slice(5, dummyAllCards.length)
+      .slice(MAX_NUMBER_OF_PLAYERS_HAND, dummyAllCards.length)
       .map((card) => {
         return {
           creatureId: card.creatureId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,80 +14,77 @@ import {
   createBattleFieldMatrix,
 } from './utils'
 
-const dummyAllCreatures: Creature[] = [
-  {
-    id: 'ally-1',
-    jobId: 'fighter',
-    lifePoint: 12,
-    attackPoint: 4,
-    skillIds: [],
-  },
-  {
-    id: 'ally-2',
-    jobId: 'knight',
-    lifePoint: 18,
-    attackPoint: 2,
-    skillIds: [],
-  },
-  {
-    id: 'ally-3',
-    jobId: 'archer',
-    lifePoint: 6,
-    attackPoint: 3,
-    skillIds: [],
-  },
-  {
-    id: 'ally-4',
-    jobId: 'mage',
-    lifePoint: 3,
-    attackPoint: 3,
-    skillIds: [],
-  },
-  {
-    id: 'ally-5',
-    jobId: 'fighter',
-    lifePoint: 12,
-    attackPoint: 4,
-    skillIds: [],
-  },
-  {
-    id: 'ally-6',
-    jobId: 'mage',
-    lifePoint: 3,
-    attackPoint: 3,
-    skillIds: [],
-  },
-  {
-    id: 'ally-7',
-    jobId: 'archer',
-    lifePoint: 6,
-    attackPoint: 3,
-    skillIds: [],
-  },
-  {
-    id: 'enemy-1',
-    jobId: 'goblin',
-    lifePoint: 4,
-    attackPoint: 1,
-    skillIds: [],
-  },
-  {
-    id: 'enemy-2',
-    jobId: 'goblin',
-    lifePoint: 4,
-    attackPoint: 1,
-    skillIds: [],
-  },
-  {
-    id: 'enemy-3',
-    jobId: 'orc',
-    lifePoint: 8,
-    attackPoint: 3,
-    skillIds: [],
-  },
-]
-const dummyAllCards: Card[] = dummyAllCreatures
-  .filter(e => /^ally-/.test(e.id))
+const dummyAllies: Creature[] = Array.from({length: 20}).map((unused, index) => {
+  const id = `ally-${index + 1}`
+  switch (index % 5) {
+    case 0:
+      return {
+        id,
+        jobId: 'fighter',
+        lifePoint: 12,
+        attackPoint: 4,
+        skillIds: [],
+      }
+    case 1:
+      return {
+        id,
+        jobId: 'knight',
+        lifePoint: 18,
+        attackPoint: 2,
+        skillIds: [],
+      }
+    case 2:
+      return {
+        id,
+        jobId: 'archer',
+        lifePoint: 6,
+        attackPoint: 3,
+        skillIds: [],
+      }
+    case 3:
+      return {
+        id,
+        jobId: 'mage',
+        lifePoint: 3,
+        attackPoint: 3,
+        skillIds: [],
+      }
+    case 4:
+      return {
+        id,
+        jobId: 'priest',
+        lifePoint: 5,
+        attackPoint: 1,
+        skillIds: [],
+      }
+    default:
+      throw new Error('')
+  }
+})
+const dummyEnemies: Creature[] = Array.from({length: 20}).map((unused, index) => {
+  const id = `enemy-${index + 1}`
+  switch (index % 2) {
+    case 0:
+      return {
+        id,
+        jobId: 'goblin',
+        lifePoint: 4,
+        attackPoint: 1,
+        skillIds: [],
+      }
+    case 1:
+      return {
+        id,
+        jobId: 'orc',
+        lifePoint: 8,
+        attackPoint: 3,
+        skillIds: [],
+      }
+    default:
+      throw new Error('')
+  }
+})
+const dummyAllCards: Card[] = dummyAllies
   .map((creature, index) => {
     const skillCategoryId = ['attack', 'defense', 'support'][index % 3] as SkillCategoryId
     return {
@@ -99,38 +96,30 @@ const dummyAllCards: Card[] = dummyAllCreatures
 function createInitialGame(): Game {
   const battleFieldMatrix = createBattleFieldMatrix(7, 7)
 
-  // "ally-1"
-  battleFieldMatrix[3][2].creatureId = dummyAllCreatures[0].id
-  // "ally-4"
-  battleFieldMatrix[2][1].creatureId = dummyAllCreatures[3].id
-  battleFieldMatrix[3][3].creatureId = dummyAllCreatures[7].id
-  battleFieldMatrix[4][3].creatureId = dummyAllCreatures[9].id
+  battleFieldMatrix[3][3].creatureId = dummyEnemies[0].id
+  battleFieldMatrix[4][3].creatureId = dummyEnemies[1].id
 
   return {
-    creatures: dummyAllCreatures,
+    creatures: dummyAllies.concat(dummyEnemies),
     parties: [
       {
         factionId: 'player',
-        creatureIds: dummyAllCreatures
-          .filter(e => /^ally-/.test(e.id))
-          .map(e => e.id),
+        creatureIds: dummyAllies.map(e => e.id),
       },
       {
         factionId: 'computer',
-        creatureIds: dummyAllCreatures
-          .filter(e => /^enemy-/.test(e.id))
-          .map(e => e.id),
+        creatureIds: dummyEnemies.map(e => e.id),
       },
     ],
     battleFieldMatrix,
     cards: dummyAllCards,
-    cardsOnYourHand: [
-      {creatureId: 'ally-2'},
-      {creatureId: 'ally-3'},
-      {creatureId: 'ally-5'},
-      {creatureId: 'ally-6'},
-      {creatureId: 'ally-7'},
-    ],
+    cardsOnYourHand: dummyAllies
+      .slice(0, 5)
+      .map((creature) => {
+        return {
+          creatureId: creature.id,
+        }
+      }),
     cursor: undefined,
     completedNormalAttackPhase: false,
     turnNumber: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ function createInitialGame(): Game {
     ],
     battleFieldMatrix,
     cards: dummyAllCards,
-    cardsOnYourHand: dummyAllCards
+    cardsOnPlayersHand: dummyAllCards
       .slice(0, MAX_NUMBER_OF_PLAYERS_HAND)
       .map((card) => {
         return {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,13 @@ function createInitialGame(): Game {
           creatureId: creature.id,
         }
       }),
+    cardsInDeck: dummyAllies
+      .slice(5, dummyAllies.length)
+      .map((creature) => {
+        return {
+          creatureId: creature.id,
+        }
+      }),
     cursor: undefined,
     completedNormalAttackPhase: false,
     turnNumber: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ function createInitialGame(): Game {
       {creatureId: 'ally-7'},
     ],
     cursor: undefined,
+    completedNormalAttackPhase: false,
     turnNumber: 1,
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -113,18 +113,18 @@ function createInitialGame(): Game {
     ],
     battleFieldMatrix,
     cards: dummyAllCards,
-    cardsOnYourHand: dummyAllies
+    cardsOnYourHand: dummyAllCards
       .slice(0, 5)
-      .map((creature) => {
+      .map((card) => {
         return {
-          creatureId: creature.id,
+          creatureId: card.creatureId,
         }
       }),
-    cardsInDeck: dummyAllies
-      .slice(5, dummyAllies.length)
-      .map((creature) => {
+    cardsInDeck: dummyAllCards
+      .slice(5, dummyAllCards.length)
+      .map((card) => {
         return {
-          creatureId: creature.id,
+          creatureId: card.creatureId,
         }
       }),
     cursor: undefined,

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -92,12 +92,12 @@ function mapBattlePageStateToProps(
     })
   })
 
-  const cardsProps: CardProps[] = game.cardsOnYourHand
+  const cardsProps: CardProps[] = game.cardsOnPlayersHand
     .map(({creatureId}, index) => {
       const card = findCardByCreatureId(game.cards, creatureId)
       const creature = findCreatureById(game.creatures, creatureId)
       const asGlobalPosition: GlobalPosition = {
-        globalPlacementId: 'cardsOnYourHand',
+        globalPlacementId: 'cardsOnPlayersHand',
         creatureId,
       }
       const isSelected = game.cursor
@@ -118,7 +118,7 @@ function mapBattlePageStateToProps(
 
   return {
     battleFieldBoard: battleFieldBoardProps,
-    cardsOnYourHand: {
+    cardsOnPlayersHand: {
       cards: cardsProps
     },
     turnNumber: game.turnNumber,

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -21,7 +21,7 @@ import {
   findCreatureWithParty,
 } from './utils'
 import {
-  proceedTurn,
+  runNormalAttackPhase,
   selectBattleFieldElement,
   selectCardOnYourHand,
 } from './reducers'
@@ -121,7 +121,7 @@ function mapBattlePageStateToProps(
     },
     turnNumber: game.turnNumber,
     handleClickNextButton: () => {
-      setState(s => proceedTurn(s))
+      setState(s => runNormalAttackPhase(s))
     },
   }
 }

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -119,6 +119,7 @@ function mapBattlePageStateToProps(
     cardsOnYourHand: {
       cards: cardsProps
     },
+    turnNumber: game.turnNumber,
     handleClickNextButton: () => {
       setState(s => proceedTurn(s))
     },

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -38,6 +38,7 @@ const jobIdToDummyImage = (jobId: string): string => {
     goblin: 'ゴ',
     knight: '重',
     mage: '魔',
+    priest: '聖',
     orc: 'オ',
   }
   return mapping[jobId] || '？'

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -21,6 +21,7 @@ import {
   findCreatureWithParty,
 } from './utils'
 import {
+  proceedTurn,
   runNormalAttackPhase,
   selectBattleFieldElement,
   selectCardOnYourHand,
@@ -121,8 +122,11 @@ function mapBattlePageStateToProps(
     },
     turnNumber: game.turnNumber,
     showNextTurnButton: game.completedNormalAttackPhase,
-    handleClickNextButton: () => {
+    handleClickBattleButton: () => {
       setState(s => runNormalAttackPhase(s))
+    },
+    handleClickNextTurnButton: () => {
+      setState(s => proceedTurn(s))
     },
   }
 }

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -122,10 +122,10 @@ function mapBattlePageStateToProps(
     },
     turnNumber: game.turnNumber,
     showNextTurnButton: game.completedNormalAttackPhase,
-    handleClickBattleButton: () => {
+    handleTouchBattleButton: () => {
       setState(s => runNormalAttackPhase(s))
     },
-    handleClickNextTurnButton: () => {
+    handleTouchNextTurnButton: () => {
       setState(s => proceedTurn(s))
     },
   }

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -120,6 +120,7 @@ function mapBattlePageStateToProps(
       cards: cardsProps
     },
     turnNumber: game.turnNumber,
+    showNextTurnButton: game.completedNormalAttackPhase,
     handleClickNextButton: () => {
       setState(s => runNormalAttackPhase(s))
     },

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -24,7 +24,7 @@ import {
   proceedTurn,
   runNormalAttackPhase,
   selectBattleFieldElement,
-  selectCardOnYourHand,
+  selectCardOnPlayersHand,
 } from './reducers'
 
 type ReactSetState = React.Dispatch<React.SetStateAction<ApplicationState>>
@@ -111,7 +111,7 @@ function mapBattlePageStateToProps(
         isFirst: index === 0,
         isSelected,
         handleTouch: (creatureId: string) => {
-          setState(s => selectCardOnYourHand(s, creatureId))
+          setState(s => selectCardOnPlayersHand(s, creatureId))
         },
       }
     })

--- a/src/reducers/__tests__/game-test.ts
+++ b/src/reducers/__tests__/game-test.ts
@@ -15,6 +15,7 @@ import {
 import {
   invokeNormalAttack,
   invokeSkill,
+  refillCardsOnYourHand,
 } from '../game'
 
 describe('reducers/game', function() {
@@ -89,6 +90,35 @@ describe('reducers/game', function() {
           assert.strictEqual(newEnemy.lifePoint < enemy.lifePoint, true)
         })
       })
+    })
+  })
+
+  describe('refillCardsOnYourHand', function() {
+    it('works', function() {
+      const result = refillCardsOnYourHand(
+        [
+          {creatureId: 'a'},
+          {creatureId: 'b'},
+          {creatureId: 'c'},
+          {creatureId: 'd'},
+          {creatureId: 'e'},
+        ],
+        [
+          {creatureId: 'x'},
+          {creatureId: 'y'},
+        ]
+      )
+      assert.deepStrictEqual(result.cardsInDeck, [
+        {creatureId: 'd'},
+        {creatureId: 'e'},
+      ])
+      assert.deepStrictEqual(result.cardsOnYourHand, [
+        {creatureId: 'x'},
+        {creatureId: 'y'},
+        {creatureId: 'a'},
+        {creatureId: 'b'},
+        {creatureId: 'c'},
+      ])
     })
   })
 })

--- a/src/reducers/__tests__/game-test.ts
+++ b/src/reducers/__tests__/game-test.ts
@@ -15,7 +15,7 @@ import {
 import {
   invokeNormalAttack,
   invokeSkill,
-  refillCardsOnYourHand,
+  refillCardsOnPlayersHand,
 } from '../game'
 
 describe('reducers/game', function() {
@@ -93,9 +93,9 @@ describe('reducers/game', function() {
     })
   })
 
-  describe('refillCardsOnYourHand', function() {
+  describe('refillCardsOnPlayersHand', function() {
     it('works', function() {
-      const result = refillCardsOnYourHand(
+      const result = refillCardsOnPlayersHand(
         [
           {creatureId: 'a'},
           {creatureId: 'b'},
@@ -112,7 +112,7 @@ describe('reducers/game', function() {
         {creatureId: 'd'},
         {creatureId: 'e'},
       ])
-      assert.deepStrictEqual(result.cardsOnYourHand, [
+      assert.deepStrictEqual(result.cardsOnPlayersHand, [
         {creatureId: 'x'},
         {creatureId: 'y'},
         {creatureId: 'a'},

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -29,10 +29,10 @@ describe('reducers/index', function() {
       beforeEach(function() {
         state = createStateDisplayBattlePageAtStartOfGame()
         battlePage = ensureBattlePage(state)
-        allyCreatureId = battlePage.game.cardsOnYourHand[0].creatureId
+        allyCreatureId = battlePage.game.cardsOnPlayersHand[0].creatureId
         battlePage.game.cursor = {
           globalPosition: {
-            globalPlacementId: 'cardsOnYourHand',
+            globalPlacementId: 'cardsOnPlayersHand',
             creatureId: allyCreatureId,
           },
         }
@@ -46,7 +46,7 @@ describe('reducers/index', function() {
 
       it('should reduce cards on player\'s hand', function() {
         assert.strictEqual(
-          battlePage.game.cardsOnYourHand.length > newBattlePage.game.cardsOnYourHand.length,
+          battlePage.game.cardsOnPlayersHand.length > newBattlePage.game.cardsOnPlayersHand.length,
           true
         )
       })
@@ -64,10 +64,10 @@ describe('reducers/index', function() {
       beforeEach(function() {
         state = createStateDisplayBattlePageAtStartOfGame()
         battlePage = ensureBattlePage(state)
-        allyCreatureId = battlePage.game.cardsOnYourHand[0].creatureId
+        allyCreatureId = battlePage.game.cardsOnPlayersHand[0].creatureId
         battlePage.game.cursor = {
           globalPosition: {
-            globalPlacementId: 'cardsOnYourHand',
+            globalPlacementId: 'cardsOnPlayersHand',
             creatureId: allyCreatureId,
           },
         }
@@ -78,7 +78,7 @@ describe('reducers/index', function() {
       })
 
       it('should not reduce cards on player\'s hand', function() {
-        assert.strictEqual(battlePage.game.cardsOnYourHand.length, newBattlePage.game.cardsOnYourHand.length)
+        assert.strictEqual(battlePage.game.cardsOnPlayersHand.length, newBattlePage.game.cardsOnPlayersHand.length)
       })
     })
   })

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -15,7 +15,7 @@ import {
   findFirstAlly,
 } from '../../test-utils'
 import {
-  proceedTurn,
+  runNormalAttackPhase,
   selectBattleFieldElement,
 } from '../index'
 
@@ -83,7 +83,7 @@ describe('reducers/index', function() {
     })
   })
 
-  describe('proceedTurn', function() {
+  describe('runNormalAttackPhase', function() {
     describe('Creatures of the hostile relations are adjacent to each other', function() {
       it('can update the result that creatures attack to each other', function() {
         const state = createStateDisplayBattlePageAtStartOfGame()
@@ -96,7 +96,7 @@ describe('reducers/index', function() {
         b.attackPoint = 1
         battlePage.game.battleFieldMatrix[0][0].creatureId = a.id
         battlePage.game.battleFieldMatrix[0][1].creatureId = b.id
-        const newState = proceedTurn(state)
+        const newState = runNormalAttackPhase(state)
         const newBattlePage = ensureBattlePage(newState)
         const newA = findFirstAlly(newBattlePage.game.creatures, newBattlePage.game.parties, 'player')
         const newB = findFirstAlly(newBattlePage.game.creatures, newBattlePage.game.parties, 'computer')
@@ -118,7 +118,7 @@ describe('reducers/index', function() {
         allies[1].attackPoint = 1
         battlePage.game.battleFieldMatrix[0][0].creatureId = allies[0].id
         battlePage.game.battleFieldMatrix[0][1].creatureId = allies[1].id
-        const newState = proceedTurn(state)
+        const newState = runNormalAttackPhase(state)
         const newBattlePage = ensureBattlePage(newState)
         const newAllies = findAllies(newBattlePage.game.creatures, newBattlePage.game.parties, 'player')
         assert.strictEqual(allies[0].lifePoint, newAllies[0].lifePoint)

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -5,6 +5,7 @@ import {
   CreatureWithParty,
   CreatureWithPartyOnBattleFieldElement,
   Party,
+  MAX_NUMBER_OF_PLAYERS_HAND,
   NormalAttackProcessContext,
   SkillProcessContext,
   determineRelationshipBetweenFactions,
@@ -165,10 +166,9 @@ export function refillCardsOnYourHand(
   cardsInDeck: CardRelationship[],
   cardsOnYourHand:CardRelationship[]
 } {
-  // TODO: Commonize "max 5"
-  const delta = 5 - cardsOnYourHand.length
+  const delta = MAX_NUMBER_OF_PLAYERS_HAND - cardsOnYourHand.length
   if (delta < 0) {
-    throw new Error('The maximum number of cards is 5.')
+    throw new Error('The player\'s hand exceeds the max number.')
   }
   return {
     cardsInDeck: cardsInDeck.slice(delta, cardsInDeck.length),

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -159,19 +159,19 @@ export function invokeSkill(context: SkillProcessContext): SkillProcessContext {
   throw new Error('It is an invalid `skillCategoryId`.')
 }
 
-export function refillCardsOnYourHand(
+export function refillCardsOnPlayersHand(
   cardsInDeck: CardRelationship[],
-  cardsOnYourHand:CardRelationship[]
+  cardsOnPlayersHand:CardRelationship[]
 ): {
   cardsInDeck: CardRelationship[],
-  cardsOnYourHand:CardRelationship[]
+  cardsOnPlayersHand:CardRelationship[]
 } {
-  const delta = MAX_NUMBER_OF_PLAYERS_HAND - cardsOnYourHand.length
+  const delta = MAX_NUMBER_OF_PLAYERS_HAND - cardsOnPlayersHand.length
   if (delta < 0) {
     throw new Error('The player\'s hand exceeds the max number.')
   }
   return {
     cardsInDeck: cardsInDeck.slice(delta, cardsInDeck.length),
-    cardsOnYourHand: cardsOnYourHand.concat(cardsInDeck.slice(0, delta)),
+    cardsOnPlayersHand: cardsOnPlayersHand.concat(cardsInDeck.slice(0, delta)),
   }
 }

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -1,5 +1,6 @@
 import {
   BattleFieldElement,
+  CardRelationship,
   Creature,
   CreatureWithParty,
   CreatureWithPartyOnBattleFieldElement,
@@ -155,4 +156,22 @@ export function invokeSkill(context: SkillProcessContext): SkillProcessContext {
     return invokeAttackSkill(context)
   }
   throw new Error('It is an invalid `skillCategoryId`.')
+}
+
+export function refillCardsOnYourHand(
+  cardsInDeck: CardRelationship[],
+  cardsOnYourHand:CardRelationship[]
+): {
+  cardsInDeck: CardRelationship[],
+  cardsOnYourHand:CardRelationship[]
+} {
+  // TODO: Commonize "max 5"
+  const delta = 5 - cardsOnYourHand.length
+  if (delta < 0) {
+    throw new Error('The maximum number of cards is 5.')
+  }
+  return {
+    cardsInDeck: cardsInDeck.slice(delta, cardsInDeck.length),
+    cardsOnYourHand: cardsOnYourHand.concat(cardsInDeck.slice(0, delta)),
+  }
 }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -23,7 +23,7 @@ import {
 import {
   invokeSkill,
   invokeNormalAttack,
-  refillCardsOnYourHand,
+  refillCardsOnPlayersHand,
 } from './game'
 
 export function selectBattleFieldElement(
@@ -81,7 +81,7 @@ export function selectBattleFieldElement(
             draft.game.parties = newContext.parties
             draft.game.battleFieldMatrix = newContext.battleFieldMatrix
             // 手札のカードを一枚減らす。
-            draft.game.cardsOnYourHand = draft.game.cardsOnYourHand
+            draft.game.cardsOnPlayersHand = draft.game.cardsOnPlayersHand
               .filter(e => e.creatureId !== cardUnderCursor.creatureId)
             // カーソルを外す。
             draft.game.cursor = undefined
@@ -94,7 +94,7 @@ export function selectBattleFieldElement(
           // クリーチャーを配置する。
           battleFieldElement.creatureId = cardUnderCursor.creatureId
           // 手札のカードを一枚減らす。
-          draft.game.cardsOnYourHand = draft.game.cardsOnYourHand
+          draft.game.cardsOnPlayersHand = draft.game.cardsOnPlayersHand
             .filter(e => e.creatureId !== cardUnderCursor.creatureId)
           // カーソルを外す。
           draft.game.cursor = undefined
@@ -120,7 +120,7 @@ export function selectCardOnYourHand(
 ): ApplicationState {
   const newBattlePage = produce(ensureBattlePage(state), draft => {
     const touchedPosition: GlobalPosition = {
-      globalPlacementId: 'cardsOnYourHand',
+      globalPlacementId: 'cardsOnPlayersHand',
       creatureId,
     }
     if (
@@ -131,7 +131,7 @@ export function selectCardOnYourHand(
     } else {
       draft.game.cursor = {
         globalPosition: {
-          globalPlacementId: 'cardsOnYourHand',
+          globalPlacementId: 'cardsOnPlayersHand',
           creatureId,
         },
       }
@@ -206,10 +206,10 @@ export function proceedTurn(
 
     // TODO: Prohibit operation
 
-    const newCardSets = refillCardsOnYourHand(draft.game.cardsInDeck, draft.game.cardsOnYourHand)
+    const newCardSets = refillCardsOnPlayersHand(draft.game.cardsInDeck, draft.game.cardsOnPlayersHand)
 
     draft.game.cardsInDeck = newCardSets.cardsInDeck
-    draft.game.cardsOnYourHand = newCardSets.cardsOnYourHand
+    draft.game.cardsOnPlayersHand = newCardSets.cardsOnPlayersHand
     draft.game.completedNormalAttackPhase = false
     draft.game.turnNumber += 1
   })

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -83,6 +83,10 @@ export function selectBattleFieldElement(
             // 手札のカードを一枚減らす。
             draft.game.cardsOnPlayersHand = draft.game.cardsOnPlayersHand
               .filter(e => e.creatureId !== cardUnderCursor.creatureId)
+            // 山札のカードへ消費したカードを戻す。
+            draft.game.cardsInDeck.push({
+              creatureId: cardUnderCursor.creatureId,
+            })
             // カーソルを外す。
             draft.game.cursor = undefined
           // 選択先クリーチャーが敵のとき。

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -144,7 +144,6 @@ export function proceedTurn(
   const newBattlePage = produce(ensureBattlePage(state), draft => {
     const game = draft.game
 
-    // TODO: ターン数を増加する。
     // TODO: アニメーション用の情報を生成する。
 
     // 攻撃者リストを抽出する。
@@ -186,6 +185,7 @@ export function proceedTurn(
     draft.game.creatures = creaturesBeingUpdated
     draft.game.parties = partiesBeingUpdated
     draft.game.battleFieldMatrix = battleFieldMatrixBeingUpdated
+    draft.game.turnNumber += 1
   })
   return Object.assign({}, state, {pages: {battle: newBattlePage}})
 }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -145,6 +145,10 @@ export function runNormalAttackPhase(
   const newBattlePage = produce(ensureBattlePage(state), draft => {
     const game = draft.game
 
+    if (game.completedNormalAttackPhase) {
+      throw new Error('The normal-attack phase is over.')
+    }
+
     // TODO: アニメーション用の情報を生成する。
 
     // 攻撃者リストを抽出する。
@@ -186,6 +190,20 @@ export function runNormalAttackPhase(
     draft.game.creatures = creaturesBeingUpdated
     draft.game.parties = partiesBeingUpdated
     draft.game.battleFieldMatrix = battleFieldMatrixBeingUpdated
+    draft.game.completedNormalAttackPhase = true
+  })
+  return Object.assign({}, state, {pages: {battle: newBattlePage}})
+}
+
+export function proceedTurn(
+  state: ApplicationState,
+): ApplicationState {
+  const newBattlePage = produce(ensureBattlePage(state), draft => {
+    if (!draft.game.completedNormalAttackPhase) {
+      throw new Error('The normal-attack phase must be completed.')
+    }
+    // TODO: Prohibit operation
+    draft.game.completedNormalAttackPhase = false
     draft.game.turnNumber += 1
   })
   return Object.assign({}, state, {pages: {battle: newBattlePage}})

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -139,7 +139,7 @@ export function selectCardOnYourHand(
   return Object.assign({}, state, {pages: {battle: newBattlePage}})
 }
 
-export function proceedTurn(
+export function runNormalAttackPhase(
   state: ApplicationState,
 ): ApplicationState {
   const newBattlePage = produce(ensureBattlePage(state), draft => {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -114,7 +114,7 @@ export function selectBattleFieldElement(
   return Object.assign({}, state, {pages: {battle: newBattlePage}})
 }
 
-export function selectCardOnYourHand(
+export function selectCardOnPlayersHand(
   state: ApplicationState,
   creatureId: Creature['id'],
 ): ApplicationState {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -23,6 +23,7 @@ import {
 import {
   invokeSkill,
   invokeNormalAttack,
+  refillCardsOnYourHand,
 } from './game'
 
 export function selectBattleFieldElement(
@@ -202,7 +203,13 @@ export function proceedTurn(
     if (!draft.game.completedNormalAttackPhase) {
       throw new Error('The normal-attack phase must be completed.')
     }
+
     // TODO: Prohibit operation
+
+    const newCardSets = refillCardsOnYourHand(draft.game.cardsInDeck, draft.game.cardsOnYourHand)
+
+    draft.game.cardsInDeck = newCardSets.cardsInDeck
+    draft.game.cardsOnYourHand = newCardSets.cardsOnYourHand
     draft.game.completedNormalAttackPhase = false
     draft.game.turnNumber += 1
   })

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -98,6 +98,7 @@ export function selectBattleFieldElement(
           // カーソルを外す。
           draft.game.cursor = undefined
         }
+      // 手札のカードへカーソルが当たっていないとき。
       } else {
         draft.game.cursor = {
           globalPosition: {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -96,6 +96,7 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
             }
           }),
           cursor: undefined,
+          completedNormalAttackPhase: false,
           turnNumber: 1,
         },
       },

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -90,6 +90,7 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           ],
           battleFieldMatrix: createBattleFieldMatrix(7, 7),
           cards,
+          cardsInDeck: [],
           cardsOnYourHand: Array.from({length: 5}).map((e, index) => {
             return {
               creatureId: allies[index].id,

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -96,6 +96,7 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
             }
           }),
           cursor: undefined,
+          turnNumber: 1,
         },
       },
     },

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -91,7 +91,7 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           battleFieldMatrix: createBattleFieldMatrix(7, 7),
           cards,
           cardsInDeck: [],
-          cardsOnYourHand: Array.from({length: 5}).map((e, index) => {
+          cardsOnPlayersHand: Array.from({length: 5}).map((e, index) => {
             return {
               creatureId: allies[index].id,
             }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,6 +33,10 @@ export type Card = {
   skillCategoryId: SkillCategoryId,
 }
 
+export type CardRelationship = {
+  creatureId: Creature['id'],
+}
+
 export type MatrixPosition = {
   x: number,
   y: number,
@@ -105,13 +109,9 @@ export type SkillProcessContext = {
 
 export type Game = {
   battleFieldMatrix: BattleFieldMatrix,
-  cardsInDeck: {
-    creatureId: Creature['id'],
-  }[],
+  cardsInDeck: CardRelationship[],
   // TODO: Max 5 cards
-  cardsOnYourHand: {
-    creatureId: Creature['id'],
-  }[],
+  cardsOnYourHand: CardRelationship[],
   cards: Card[],
   completedNormalAttackPhase: boolean,
   creatures: Creature[],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -113,6 +113,7 @@ export type Game = {
   creatures: Creature[],
   cursor: Cursor | undefined,
   parties: Party[],
+  turnNumber: number,
 }
 
 export type BattlePage = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,12 +50,12 @@ type BattleFieldElementPosition = {
   y: MatrixPosition['y'],
 }
 
-type CardOnYourHandPosition = {
+type CardOnPlayersHandPosition = {
   creatureId: Creature['id'],
   globalPlacementId: 'cardsOnPlayersHand',
 }
 
-export type GlobalPosition = BattleFieldElementPosition | CardOnYourHandPosition
+export type GlobalPosition = BattleFieldElementPosition | CardOnPlayersHandPosition
 
 export function isBattleFieldMatrixPositionType(
   globalPosition: GlobalPosition
@@ -65,7 +65,7 @@ export function isBattleFieldMatrixPositionType(
 
 function isCardsOnPlayersHandPositionType(
   globalPosition: GlobalPosition
-): globalPosition is CardOnYourHandPosition {
+): globalPosition is CardOnPlayersHandPosition {
   return globalPosition.globalPlacementId === 'cardsOnPlayersHand'
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,7 +110,6 @@ export type SkillProcessContext = {
 export type Game = {
   battleFieldMatrix: BattleFieldMatrix,
   cardsInDeck: CardRelationship[],
-  // TODO: Max 5 cards
   cardsOnYourHand: CardRelationship[],
   cards: Card[],
   completedNormalAttackPhase: boolean,
@@ -129,6 +128,8 @@ export type ApplicationState = {
     battle?: BattlePage,
   },
 }
+
+export const MAX_NUMBER_OF_PLAYERS_HAND = 5
 
 /**
  * Validate that the matrix is not empty and is rectangular

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -110,6 +110,7 @@ export type Game = {
     creatureId: Creature['id'],
   }[],
   cards: Card[],
+  completedNormalAttackPhase: boolean,
   creatures: Creature[],
   cursor: Cursor | undefined,
   parties: Party[],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,6 +105,9 @@ export type SkillProcessContext = {
 
 export type Game = {
   battleFieldMatrix: BattleFieldMatrix,
+  cardsInDeck: {
+    creatureId: Creature['id'],
+  }[],
   // TODO: Max 5 cards
   cardsOnYourHand: {
     creatureId: Creature['id'],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export type MatrixPosition = {
   y: number,
 }
 
-type GlobalPlacementId = 'battleFieldMatrix' | 'cardsOnYourHand'
+type GlobalPlacementId = 'battleFieldMatrix' | 'cardsOnPlayersHand'
 
 type BattleFieldElementPosition = {
   globalPlacementId: 'battleFieldMatrix',
@@ -52,7 +52,7 @@ type BattleFieldElementPosition = {
 
 type CardOnYourHandPosition = {
   creatureId: Creature['id'],
-  globalPlacementId: 'cardsOnYourHand',
+  globalPlacementId: 'cardsOnPlayersHand',
 }
 
 export type GlobalPosition = BattleFieldElementPosition | CardOnYourHandPosition
@@ -63,10 +63,10 @@ export function isBattleFieldMatrixPositionType(
   return globalPosition.globalPlacementId === 'battleFieldMatrix'
 }
 
-export function isCardsOnYourHandPositionType(
+function isCardsOnPlayersHandPositionType(
   globalPosition: GlobalPosition
 ): globalPosition is CardOnYourHandPosition {
-  return globalPosition.globalPlacementId === 'cardsOnYourHand'
+  return globalPosition.globalPlacementId === 'cardsOnPlayersHand'
 }
 
 export type BattleFieldElement = {
@@ -110,7 +110,7 @@ export type SkillProcessContext = {
 export type Game = {
   battleFieldMatrix: BattleFieldMatrix,
   cardsInDeck: CardRelationship[],
-  cardsOnYourHand: CardRelationship[],
+  cardsOnPlayersHand: CardRelationship[],
   cards: Card[],
   completedNormalAttackPhase: boolean,
   creatures: Creature[],
@@ -166,7 +166,7 @@ export const ensureBattlePage = (state: ApplicationState): BattlePage => {
 export function areGlobalPositionsEqual(a: GlobalPosition, b: GlobalPosition): boolean {
   if (isBattleFieldMatrixPositionType(a) && isBattleFieldMatrixPositionType(b)) {
     return a.y === b.y && a.x === b.x
-  } else if (isCardsOnYourHandPositionType(a) && isCardsOnYourHandPositionType(b)) {
+  } else if (isCardsOnPlayersHandPositionType(a) && isCardsOnPlayersHandPositionType(b)) {
     return a.creatureId === b.creatureId
   }
   return false
@@ -298,7 +298,7 @@ export function pickBattleFieldElementsWhereCreatureExists(
 export function findCardUnderCursor(cards: Card[], cursor: Cursor): Card | undefined {
   for (const card of cards) {
     const position: GlobalPosition = {
-      globalPlacementId: 'cardsOnYourHand',
+      globalPlacementId: 'cardsOnPlayersHand',
       creatureId: card.creatureId,
     }
     if (areGlobalPositionsEqual(position, cursor.globalPosition)) {


### PR DESCRIPTION
- [x] ターンの経過
  - [x] ターン数を表示する。
  - [x] ターンの確定までには Next ボタンを二回押すようにする。
    - [x] カード使用の確定で一回、通常攻撃解決後のターン全体の確定で一回、に分ける。
      - [x] 後者が完了しているかのフラグを作る。
    - [x] それぞれでボタンの表記を変える。
  - [x] 手札が山札から補充される。
    - [x] 山札のデータを定義する。
  - [x] スキル使用時に消費した手札を山札へ戻す。