### PR TITLE
Creature dies

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -97,9 +97,6 @@ const dummyAllCards: Card[] = dummyAllies
 function createInitialGame(): Game {
   const battleFieldMatrix = createBattleFieldMatrix(7, 7)
 
-  battleFieldMatrix[3][3].creatureId = dummyEnemies[0].id
-  battleFieldMatrix[4][3].creatureId = dummyEnemies[1].id
-
   return {
     creatures: dummyAllies.concat(dummyEnemies),
     parties: [

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -150,7 +150,7 @@ describe('reducers/index', function() {
     })
 
     describe('computer 側の攻撃で死亡する player 側のクリーチャーが存在するとき', function() {
-      it('死亡した player 側のクリーチャーが手札の末尾へ戻る結果を返す', function() {
+      it('死亡した player 側のクリーチャーが山札の末尾へ戻る結果を返す', function() {
         const state = createStateDisplayBattlePageAtStartOfGame()
         const battlePage = ensureBattlePage(state)
         const a = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'player')

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert'
-import {describe, it} from 'mocha'
+import {describe, it, beforeEach} from 'mocha'
 
 import {
   ApplicationState,
@@ -84,18 +84,26 @@ describe('reducers/index', function() {
   })
 
   describe('runNormalAttackPhase', function() {
-    describe('Creatures of the hostile relations are adjacent to each other', function() {
-      it('can update the result that creatures attack to each other', function() {
-        const state = createStateDisplayBattlePageAtStartOfGame()
-        const battlePage = ensureBattlePage(state)
-        const a = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'player')
-        const b = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'computer')
+    describe('敵対関係であるクリーチャーが隣接しているとき', function() {
+      let state: ApplicationState
+      let battlePage: BattlePage
+      let a: Creature
+      let b: Creature
+
+      beforeEach(function() {
+        state = createStateDisplayBattlePageAtStartOfGame()
+        battlePage = ensureBattlePage(state)
+        a = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'player')
+        b = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'computer')
+        battlePage.game.battleFieldMatrix[0][0].creatureId = a.id
+        battlePage.game.battleFieldMatrix[0][1].creatureId = b.id
+      })
+
+      it('互いに攻撃した結果を返す', function() {
         a.lifePoint = 2
         a.attackPoint = 1
         b.lifePoint = 2
         b.attackPoint = 1
-        battlePage.game.battleFieldMatrix[0][0].creatureId = a.id
-        battlePage.game.battleFieldMatrix[0][1].creatureId = b.id
         const newState = runNormalAttackPhase(state)
         const newBattlePage = ensureBattlePage(newState)
         const newA = findFirstAlly(newBattlePage.game.creatures, newBattlePage.game.parties, 'player')
@@ -105,10 +113,25 @@ describe('reducers/index', function() {
         assert.notStrictEqual(b.lifePoint, newB.lifePoint)
         assert.strictEqual(b.lifePoint > newB.lifePoint, true)
       })
+
+      describe('a クリーチャーの攻撃で b クリーチャーが死亡するとき', function() {
+        beforeEach(function() {
+          a.lifePoint = 10
+          a.attackPoint = 1
+          b.lifePoint = 1
+          b.attackPoint = 1
+        })
+
+        it('b が盤上に存在しない結果を返す', function() {
+          const newState = runNormalAttackPhase(state)
+          const newBattlePage = ensureBattlePage(newState)
+          assert.strictEqual(newBattlePage.game.battleFieldMatrix[0][1].creatureId, undefined)
+        })
+      })
     })
 
-    describe('Creatures of the friendly relations are adjacent to each other', function() {
-      it('can update the result that creatures does not attack to each other', function() {
+    describe('味方関係であるクリーチャーが隣接しているとき', function() {
+      it('互いに攻撃しなかった結果を返す', function() {
         const state = createStateDisplayBattlePageAtStartOfGame()
         const battlePage = ensureBattlePage(state)
         const allies = findAllies(battlePage.game.creatures, battlePage.game.parties, 'player')
@@ -123,6 +146,27 @@ describe('reducers/index', function() {
         const newAllies = findAllies(newBattlePage.game.creatures, newBattlePage.game.parties, 'player')
         assert.strictEqual(allies[0].lifePoint, newAllies[0].lifePoint)
         assert.strictEqual(allies[1].lifePoint, newAllies[1].lifePoint)
+      })
+    })
+
+    describe('computer 側の攻撃で死亡する player 側のクリーチャーが存在するとき', function() {
+      it('死亡した player 側のクリーチャーが手札の末尾へ戻る結果を返す', function() {
+        const state = createStateDisplayBattlePageAtStartOfGame()
+        const battlePage = ensureBattlePage(state)
+        const a = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'player')
+        const b = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'computer')
+        a.lifePoint = 1
+        a.attackPoint = 1
+        b.lifePoint = 10
+        b.attackPoint = 1
+        battlePage.game.battleFieldMatrix[0][0].creatureId = a.id
+        battlePage.game.battleFieldMatrix[0][1].creatureId = b.id
+        const cardsInDeck = battlePage.game.cardsInDeck
+        const newState = runNormalAttackPhase(state)
+        const newBattlePage = ensureBattlePage(newState)
+        const newCardsInDeck = newBattlePage.game.cardsInDeck
+        assert.strictEqual(newCardsInDeck.length > cardsInDeck.length, true)
+        assert.strictEqual(newCardsInDeck[newCardsInDeck.length - 1].creatureId, a.id)
       })
     })
   })

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -74,6 +74,9 @@ export function invokeNormalAttack(context: NormalAttackProcessContext): NormalA
     .slice(0, dummyMaxNumberOfTargetees)
 
   // 影響を決定する。
+  // NOTE: このループ内で攻撃対象が死亡するなどしても、対象から除外しなくても良い。
+  //       通常攻撃の副作用で攻撃者に有利な効果が発生することもあり、それが意図せずに発生しないと損な感じが強そう。
+  //       それにより、死亡しているクリーチャーも攻撃対象に含まれることになる。
   const affectedCreatures: Creature[] = targeteesData
     .map(targeteeData => {
       const dummyDamage = 1

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -23,6 +23,11 @@ import {
   pickBattleFieldElementsWhereCreatureExists,
 } from '../utils';
 
+export const creatureUtils = {
+  canAct: (creature: Creature): boolean => !creatureUtils.isDead(creature),
+  isDead: (creature: Creature): boolean => creature.lifePoint === 0,
+}
+
 export function invokeNormalAttack(context: NormalAttackProcessContext): NormalAttackProcessContext {
   const attackerWithParty = findCreatureWithParty(context.creatures, context.parties, context.attackerCreatureId)
 

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -179,7 +179,8 @@ export function runNormalAttackPhase(
 
     // 攻撃者リストをループしてそれぞれの通常攻撃を発動する。
     attackerDataList.forEach((attackerData) => {
-      // Only the "creature.id" should be referred because other properties may be updated.
+      // NOTE: この id と直上でまとめた更新用の値以外は参照しないこと。
+      //       他の値はループ処理が始まれば陳腐化するため。
       const attackerCreatureId = attackerData.creature.id
 
       const attackerWithParty = findCreatureWithParty(

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -21,6 +21,7 @@ import {
   pickBattleFieldElementsWhereCreatureExists,
 } from '../utils'
 import {
+  creatureUtils,
   determinePositionsOfCreatureAppearance,
   invokeSkill,
   invokeNormalAttack,
@@ -180,6 +181,14 @@ export function runNormalAttackPhase(
     attackerDataList.forEach((attackerData) => {
       // Only the "creature.id" should be referred because other properties may be updated.
       const attackerCreatureId = attackerData.creature.id
+
+      const attackerWithParty = findCreatureWithParty(
+        creaturesBeingUpdated, partiesBeingUpdated, attackerCreatureId)
+
+      // 攻撃者が行動不能のとき。
+      if (!creatureUtils.canAct(attackerWithParty.creature)) {
+        return
+      }
 
       const result = invokeNormalAttack({
         attackerCreatureId,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -3,10 +3,8 @@ import produce from 'immer'
 import {
   ApplicationState,
   BattleFieldElement,
-  BattleFieldMatrix,
   BattlePage,
   Card,
-  CardRelationship,
   Creature,
   CreatureWithParty,
   CreatureWithPartyOnBattleFieldElement,
@@ -176,11 +174,10 @@ export function runNormalAttackPhase(
 
     // TODO: 攻撃者リストを発動順に整列する。
 
-    // TODO: Use typeof
-    let creaturesBeingUpdated: Creature[] = game.creatures
-    let partiesBeingUpdated: Party[] = game.parties
-    let battleFieldMatrixBeingUpdated: BattleFieldMatrix = game.battleFieldMatrix
-    let cardsInDeckBeingUpdated: CardRelationship[] = game.cardsInDeck
+    let creaturesBeingUpdated = game.creatures
+    let partiesBeingUpdated = game.parties
+    let battleFieldMatrixBeingUpdated = game.battleFieldMatrix
+    let cardsInDeckBeingUpdated = game.cardsInDeck
 
     // 攻撃者リストをループしてそれぞれの通常攻撃を発動する。
     attackerDataList.forEach((attackerData) => {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -16,7 +16,9 @@ import {
   areGlobalPositionsEqual,
   determineRelationshipBetweenFactions,
   ensureBattlePage,
+  findBattleFieldElementByCreatureId,
   findCardUnderCursor,
+  findCreatureById,
   findCreatureWithParty,
   pickBattleFieldElementsWhereCreatureExists,
 } from '../utils'
@@ -198,9 +200,24 @@ export function runNormalAttackPhase(
         battleFieldMatrix: battleFieldMatrixBeingUpdated,
       })
 
+      // 攻撃により死亡したクリーチャーが存在する位置をまとめる。
+      const positionsOfDeadCreature: MatrixPosition[] = []
+      for (const element of pickBattleFieldElementsWhereCreatureExists(result.battleFieldMatrix)) {
+        if (element.creatureId !== undefined) {
+          const creature = findCreatureById(result.creatures, element.creatureId)
+          if (creatureUtils.isDead(creature)) {
+            positionsOfDeadCreature.push(element.position)
+          }
+        }
+      }
+
       creaturesBeingUpdated = result.creatures
       partiesBeingUpdated = result.parties
       battleFieldMatrixBeingUpdated = result.battleFieldMatrix
+      positionsOfDeadCreature.forEach(position => {
+        // TODO: 味方は手札に戻す必要がある。
+        battleFieldMatrixBeingUpdated[position.y][position.x].creatureId = undefined
+      })
     })
 
     draft.game.creatures = creaturesBeingUpdated

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -65,8 +65,8 @@ export function selectBattleFieldElement(
       if (cardUnderCursor) {
         // 選択先のマスへクリーチャーが配置されているとき。
         if (placedCreatureWithParty) {
-          // 選択先クリーチャーが味方のとき。
-          if (determineRelationshipBetweenFactions('player', placedCreatureWithParty.party.factionId) === 'ally') {
+          // 選択先クリーチャーがプレイヤー側のとき。
+          if (placedCreatureWithParty.party.factionId === 'player') {
             // TODO: 発動できない状況を除外する。
             // スキルを発動する。
             const newContext = invokeSkill({
@@ -118,7 +118,7 @@ export function selectBattleFieldElement(
             })
             // カーソルを外す。
             draft.game.cursor = undefined
-          // 選択先クリーチャーが敵のとき。
+          // 選択先クリーチャーがプレイヤー側ではないとき。
           } else {
             /* no-op */
           }


### PR DESCRIPTION
- [x] クリーチャーが死亡する。
  - [x] 死亡か否かの判定ができる。
  - [x] 死亡したクリーチャーは行動不能である。
  - [x] 行動不能のクリーチャーは通常攻撃ができない。
  - [x] 通常攻撃により死亡する。
    - [x] いち攻撃者分の通常攻撃の終了時に、盤上から死亡者を取り除く。
    - [x] プレイヤーのクリーチャーのときは、山札の末尾へ戻る。
  - [x] 行動不能のクリーチャーはスキルを使えなくする。
  - [x] スキル発動により死亡する。
    - [x] いちスキル発動の終了時に、盤上から死亡者を取り除く。
    - [x] プレイヤーのクリーチャーのときは、山札の末尾へ戻る。