### PR TITLE
Organize placement logics

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,12 @@ const dummyAllCards: Card[] = dummyAllies
       creatureId: creature.id,
     }
   })
+const dummyCreatureAppearances = dummyEnemies.map((creature, index) => {
+  return {
+    turnNumber: index + 1,
+    creatureIds: [creature.id],
+  }
+})
 
 function createInitialGame(): Game {
   const battleFieldMatrix = createBattleFieldMatrix(7, 7)
@@ -125,12 +131,7 @@ function createInitialGame(): Game {
           creatureId: card.creatureId,
         }
       }),
-    creatureAppearances: dummyEnemies.map((creature, index) => {
-      return {
-        turnNumber: index + 1,
-        creatureIds: [creature.id],
-      }
-    }),
+    creatureAppearances: dummyCreatureAppearances,
     cursor: undefined,
     completedNormalAttackPhase: false,
     turnNumber: 1,

--- a/src/reducers/__tests__/game-test.ts
+++ b/src/reducers/__tests__/game-test.ts
@@ -1,5 +1,8 @@
 import * as assert from 'assert'
-import {describe, it} from 'mocha'
+import {
+  describe,
+  it,
+} from 'mocha'
 
 import {
   NormalAttackProcessContext,
@@ -16,6 +19,7 @@ import {
   determinePositionsOfCreatureAppearance,
   invokeNormalAttack,
   invokeSkill,
+  placePlayerFactionCreature,
   refillCardsOnPlayersHand,
 } from '../game'
 
@@ -91,6 +95,35 @@ describe('reducers/game', function() {
           assert.strictEqual(newEnemy.lifePoint < enemy.lifePoint, true)
         })
       })
+    })
+  })
+
+  describe('placePlayerFactionCreature', function() {
+    it('指定したマスにクリーチャーが存在するとき、例外を発生する', function() {
+      const matrix = createBattleFieldMatrix(1, 1)
+      matrix[0][0].creatureId = 'a'
+      assert.throws(() => {
+        placePlayerFactionCreature(matrix, [], 'b', {y: 0, x: 0})
+      }, /creature exist/)
+    })
+
+    it('指定したクリーチャーが手札にないとき、例外を発生する', function() {
+      const matrix = createBattleFieldMatrix(1, 1)
+      assert.throws(() => {
+        placePlayerFactionCreature(matrix, [], 'a', {y: 0, x: 0})
+      }, /does not exist/)
+    })
+
+    it('盤上へクリーチャーが配置される', function() {
+      const matrix = createBattleFieldMatrix(1, 1)
+      const result = placePlayerFactionCreature(matrix, [{creatureId: 'a'}], 'a', {y: 0, x: 0})
+      assert.strictEqual(result.battleFieldMatrix[0][0].creatureId, 'a')
+    })
+
+    it('指定したクリーチャーのカードが手札から削除される', function() {
+      const matrix = createBattleFieldMatrix(1, 1)
+      const result = placePlayerFactionCreature(matrix, [{creatureId: 'a'}, {creatureId: 'b'}], 'a', {y: 0, x: 0})
+      assert.deepStrictEqual(result.cardsOnPlayersHand, [{creatureId: 'b'}])
     })
   })
 

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -205,6 +205,38 @@ export function determinePositionsOfCreatureAppearance(
   return []
 }
 
+export function placePlayerFactionCreature(
+  battleFieldMatrix: BattleFieldMatrix,
+  cardsOnPlayersHand: CardRelationship[],
+  creatureId: Creature['id'],
+  position: MatrixPosition
+): {
+  battleFieldMatrix: BattleFieldMatrix,
+  cardsOnPlayersHand: CardRelationship[],
+} {
+  const element = battleFieldMatrix[position.y][position.x]
+  // NOTE: 欲しい仕様ではないが、今はこの状況にならないはず。
+  if (element.creatureId !== undefined) {
+    throw new Error('A creature exist in the battle field element.')
+  }
+
+  let newBattleFieldMatrix = battleFieldMatrix.slice()
+  newBattleFieldMatrix[position.y] = newBattleFieldMatrix[position.y].slice()
+  newBattleFieldMatrix[position.y][position.x] = {
+    ...newBattleFieldMatrix[position.y][position.x],
+    creatureId,
+  }
+  const newCardsOnPlayersHand = cardsOnPlayersHand.filter(e => e.creatureId !== creatureId)
+  if (newCardsOnPlayersHand.length === cardsOnPlayersHand.length) {
+    throw new Error('The `creatureId` does not exist on the player\'s hand.')
+  }
+
+  return {
+    battleFieldMatrix: newBattleFieldMatrix,
+    cardsOnPlayersHand: newCardsOnPlayersHand,
+  }
+}
+
 export function refillCardsOnPlayersHand(
   cardsInDeck: CardRelationship[],
   cardsOnPlayersHand:CardRelationship[]

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -27,6 +27,7 @@ import {
   determinePositionsOfCreatureAppearance,
   invokeSkill,
   invokeNormalAttack,
+  placePlayerFactionCreature,
   refillCardsOnPlayersHand,
 } from './game'
 
@@ -131,10 +132,16 @@ export function selectBattleFieldElement(
         // 選択先のマスへクリーチャーが配置されていないとき。
         } else {
           // クリーチャーを配置する。
-          battleFieldElement.creatureId = cardUnderCursor.creatureId
-          // 手札のカードを一枚減らす。
-          draft.game.cardsOnPlayersHand = draft.game.cardsOnPlayersHand
-            .filter(e => e.creatureId !== cardUnderCursor.creatureId)
+          // 手札からそのクリーチャーのカードを削除する。
+          draft.game = {
+            ...draft.game,
+            ...placePlayerFactionCreature(
+              draft.game.battleFieldMatrix,
+              draft.game.cardsOnPlayersHand,
+              cardUnderCursor.creatureId,
+              battleFieldElement.position
+            ),
+          }
           // カーソルを外す。
           draft.game.cursor = undefined
         }

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -300,7 +300,7 @@ export function proceedTurn(
     }
 
     // クリーチャーの出現が予約される。
-    const creatureAppearances = determinePositionsOfCreatureAppearance(
+    const reservedCreaturePositions = determinePositionsOfCreatureAppearance(
       draft.game.battleFieldMatrix,
       draft.game.creatureAppearances,
       draft.game.turnNumber,
@@ -317,7 +317,7 @@ export function proceedTurn(
       element.creatureId = element.reservedCreatureId
       element.reservedCreatureId = undefined
     })
-    creatureAppearances.forEach(({position, creatureId}) => {
+    reservedCreaturePositions.forEach(({position, creatureId}) => {
       draft.game.battleFieldMatrix[position.y][position.x].reservedCreatureId = creatureId
     })
     draft.game.cardsInDeck = newCardSets.cardsInDeck

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -3,6 +3,7 @@ import {
   Card,
   Creature,
   FactionId,
+  MAX_NUMBER_OF_PLAYERS_HAND,
   Party,
   createBattleFieldMatrix,
   determineRelationshipBetweenFactions,
@@ -90,12 +91,8 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           ],
           battleFieldMatrix: createBattleFieldMatrix(7, 7),
           cards,
-          cardsInDeck: [],
-          cardsOnPlayersHand: Array.from({length: 5}).map((e, index) => {
-            return {
-              creatureId: allies[index].id,
-            }
-          }),
+          cardsInDeck: cards.slice(MAX_NUMBER_OF_PLAYERS_HAND).map(e => ({creatureId: e.creatureId})),
+          cardsOnPlayersHand: cards.slice(0, MAX_NUMBER_OF_PLAYERS_HAND).map(e => ({creatureId: e.creatureId})),
           creatureAppearances: [],
           cursor: undefined,
           completedNormalAttackPhase: false,


### PR DESCRIPTION
- [x] 配置処理を整理する。
  - [x] 配置処理を共通化する。
    - [x] プレイヤーのクリーチャーの配置を共通化する。
      - [x] reducer のテスト内でも正しく配置する。
    - [x] ~~コンピューターのクリーチャーの配置を共通化する。~~
      - 複数の状態に同期することがなかったので不要だった。