### PR TITLE
Win-loss judgement

### DIFF
--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -6,6 +6,7 @@ import {
   BattleFieldMatrix,
   Card,
   MatrixPosition,
+  Party,
   areGlobalPositionsEqual,
   choiceElementsAtRandom,
   createBattleFieldMatrix,
@@ -13,6 +14,7 @@ import {
   findBattleFieldElementsByDistance,
   findCardUnderCursor,
   findCardsByCreatureIds,
+  findPartyByCreatureId,
   flattenMatrix,
   measureDistance,
   pickBattleFieldElementsWhereCreatureExists,
@@ -143,9 +145,29 @@ describe('utils', function() {
       assert.deepStrictEqual(
         flattenMatrix<number>([[1, 2], [3, 4]]),
         [1, 2, 3, 4],
-      );
-    });
-  });
+      )
+    })
+  })
+
+  describe('findPartyByCreatureId', function() {
+    describe('creatureId がいずれかの Party に所属するとき', function() {
+      it('所属先の Party を返す', function() {
+        const parties: Party[] = [
+          {factionId: 'player', creatureIds: ['a']},
+          {factionId: 'computer', creatureIds: ['b']},
+        ]
+        assert.strictEqual(findPartyByCreatureId(parties, 'b'), parties[1])
+      })
+    })
+
+    describe('creatureId がどの Party にも所属しないとき', function() {
+      it('例外を発生する', function() {
+        assert.throws(() => {
+          findPartyByCreatureId([], 'a')
+        }, /creatureId/)
+      })
+    })
+  })
 
   describe('areGlobalPositionsEqual', function() {
     describe('a=BattleFieldMatrixPosition, b=BattleFieldMatrixPosition', function() {

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -270,9 +270,10 @@ const CardsOnPlayersHand: React.FC<CardsOnPlayersHandProps> = (props) => {
 }
 
 type FooterProps = {
-  handleTouchBattleButton: () => void,
-  handleTouchNextTurnButton: () => void,
-  showNextTurnButton: boolean,
+  progressButton: {
+    label: string,
+    handleTouch: () => void,
+  },
 }
 
 const Footer: React.FC<FooterProps> = (props) => {
@@ -320,29 +321,16 @@ const Footer: React.FC<FooterProps> = (props) => {
       }}>
         <div>5</div>
       </div>
-      {
-        props.showNextTurnButton
-        ? <div
-          style={rightSideButtonStyle}
-          onTouchStart={props.handleTouchNextTurnButton}
-        >
-          <div
-            style={{
-              fontSize: '24px',
-            }}
-          >Next</div>
-        </div>
-        : <div
-          style={rightSideButtonStyle}
-          onTouchStart={props.handleTouchBattleButton}
-        >
-          <div
-            style={{
-              fontSize: '24px',
-            }}
-          >Battle</div>
-        </div>
-      }
+      <div
+        style={rightSideButtonStyle}
+        onTouchStart={props.progressButton.handleTouch}
+      >
+        <div
+          style={{
+            fontSize: '24px',
+          }}
+        >{props.progressButton.label}</div>
+      </div>
     </div>
   )
 }
@@ -354,10 +342,8 @@ export type Props = {
     updatesAreProhibited: boolean,
   },
   cardsOnPlayersHand: CardsOnPlayersHandProps,
-  handleTouchBattleButton: FooterProps['handleTouchBattleButton'],
-  handleTouchNextTurnButton: FooterProps['handleTouchNextTurnButton'],
+  progressButton: FooterProps['progressButton'],
   turnNumber: MetaInformationBarProps['turnNumber'],
-  showNextTurnButton: FooterProps['showNextTurnButton'],
 }
 
 export const BattlePage: React.FC<Props> = (props) => {
@@ -375,9 +361,7 @@ export const BattlePage: React.FC<Props> = (props) => {
       <SquareMonitor />
       <CardsOnPlayersHand {...props.cardsOnPlayersHand} />
       <Footer
-        handleTouchBattleButton={props.handleTouchBattleButton}
-        handleTouchNextTurnButton={props.handleTouchNextTurnButton}
-        showNextTurnButton={props.showNextTurnButton}
+        progressButton={props.progressButton}
       />
     </div>
   )

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,9 @@ function createInitialGame(): Game {
     cursor: undefined,
     completedNormalAttackPhase: false,
     turnNumber: 1,
+    battleResult: {
+      victoryOrDefeatId: 'pending',
+    },
     headquartersLifePoint: 10,
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,12 +99,14 @@ const dummyAllCards: Card[] = dummyAllies
       creatureId: creature.id,
     }
   })
-const dummyCreatureAppearances = dummyEnemies.map((creature, index) => {
-  return {
-    turnNumber: index,
-    creatureIds: [creature.id],
-  }
-})
+const dummyCreatureAppearances = dummyEnemies
+  .slice(0, 10)
+  .map((creature, index) => {
+    return {
+      turnNumber: index,
+      creatureIds: [creature.id],
+    }
+  })
 
 function createInitialGame(): Game {
   const battleFieldMatrix = createBattleFieldMatrix(7, 7)

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,7 @@ function createInitialGame(): Game {
     cursor: undefined,
     completedNormalAttackPhase: false,
     turnNumber: 1,
+    headquartersLifePoint: 10,
   }
 
   game = {

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -123,7 +123,7 @@ function mapBattlePageStateToProps(
       handleTouch({y, x}) {
         setState(s => selectBattleFieldElement(s, y, x))
       },
-      updatesAreProhibited: game.completedNormalAttackPhase,
+      updatesAreProhibited: game.battleResult.victoryOrDefeatId !== 'pending' || game.completedNormalAttackPhase,
     },
     cardsOnPlayersHand: {
       cards: cardsProps

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -117,6 +117,30 @@ function mapBattlePageStateToProps(
       }
     })
 
+  const progressButton = game.battleResult.victoryOrDefeatId === 'pending'
+    ? game.completedNormalAttackPhase
+      ? {
+        label: 'Next',
+        handleTouch: () => {
+          setState(s => proceedTurn(s))
+        },
+      }
+      : {
+        label: 'Battle',
+        handleTouch: () => {
+          setState(s => runNormalAttackPhase(s))
+        },
+      }
+    : game.battleResult.victoryOrDefeatId === 'victory'
+      ? {
+        label: 'Victory!',
+        handleTouch: () => {},
+      }
+      : {
+        label: 'Defeat...',
+        handleTouch: () => {},
+      }
+
   return {
     battleFieldBoard: {
       board: boardProps,
@@ -129,13 +153,7 @@ function mapBattlePageStateToProps(
       cards: cardsProps
     },
     turnNumber: game.turnNumber,
-    showNextTurnButton: game.completedNormalAttackPhase,
-    handleTouchBattleButton: () => {
-      setState(s => runNormalAttackPhase(s))
-    },
-    handleTouchNextTurnButton: () => {
-      setState(s => proceedTurn(s))
-    },
+    progressButton,
   }
 }
 

--- a/src/reducers/__tests__/game-test.ts
+++ b/src/reducers/__tests__/game-test.ts
@@ -21,6 +21,7 @@ import {
   findFirstAlly,
 } from '../../test-utils'
 import {
+  determineVictoryOrDefeat,
   doesPlayerHaveDefeat,
   doesPlayerHaveVictory,
   invokeNormalAttack,
@@ -92,6 +93,28 @@ describe('reducers/game', function() {
     it('works', function() {
       assert.strictEqual(doesPlayerHaveDefeat(0), true)
       assert.strictEqual(doesPlayerHaveDefeat(1), false)
+    })
+  })
+
+  describe('determineVictoryOrDefeat', function() {
+    it('勝利条件と敗北条件を同時に満たすときは勝利を返す', function() {
+      const parties: Party[] = [
+        {factionId: 'computer', creatureIds: ['a']},
+      ]
+      const battleFieldMatrix = createBattleFieldMatrix(1, 1)
+      const creatureAppearances: CreatureAppearance[] = [
+        {turnNumber: 1, creatureIds: ['a']},
+      ]
+      assert.strictEqual(
+        determineVictoryOrDefeat(
+          parties,
+          battleFieldMatrix,
+          creatureAppearances,
+          1,
+          0
+        ),
+        'victory'
+      )
     })
   })
 

--- a/src/reducers/__tests__/game-test.ts
+++ b/src/reducers/__tests__/game-test.ts
@@ -7,6 +7,7 @@ import {
 import {
   BattleFieldMatrix,
   Creature,
+  CreatureAppearance,
   NormalAttackProcessContext,
   Party,
   SkillProcessContext,
@@ -20,6 +21,8 @@ import {
   findFirstAlly,
 } from '../../test-utils'
 import {
+  doesPlayerHaveDefeat,
+  doesPlayerHaveVictory,
   invokeNormalAttack,
   invokeSkill,
   placePlayerFactionCreature,
@@ -29,6 +32,69 @@ import {
 } from '../game'
 
 describe('reducers/game', function() {
+  describe('doesPlayerHaveVictory', function() {
+    const parties: Party[] = [
+      {factionId: 'player', creatureIds: ['x']},
+      {factionId: 'computer', creatureIds: ['a', 'b']},
+    ]
+    const creatureAppearances: CreatureAppearance[] = [
+      {turnNumber: 1, creatureIds: ['a']},
+      {turnNumber: 2, creatureIds: ['b']},
+    ]
+
+    describe('ターン数が、computer 側クリーチャーの出現する最後のターンのとき', function() {
+      const currentTurnNumber = 2
+
+      it('予約の computer 側クリーチャーが盤上に存在するとき、勝利ではない', function() {
+        const battleFieldMatrix = createBattleFieldMatrix(1, 1)
+        battleFieldMatrix[0][0].reservedCreatureId = 'a'
+        assert.strictEqual(
+          doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber),
+          false
+        )
+      })
+
+      it('computer 側クリーチャーが盤上に存在するとき、勝利ではない', function() {
+        const battleFieldMatrix = createBattleFieldMatrix(1, 1)
+        battleFieldMatrix[0][0].creatureId = 'a'
+        assert.strictEqual(
+          doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber),
+          false
+        )
+      })
+
+      describe('予約を含む computer 側クリーチャーが盤上に存在しないとき', function() {
+        it('player 側クリーチャーが盤上に存在するときでも、勝利である', function() {
+          const battleFieldMatrix = createBattleFieldMatrix(1, 1)
+          battleFieldMatrix[0][0].creatureId = 'x'
+          assert.strictEqual(
+            doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber),
+            true
+          )
+        })
+      })
+    })
+
+    describe('ターン数が、computer 側クリーチャーの出現する最後のターン未満のとき', function() {
+      const currentTurnNumber = 1
+
+      it('予約を含む computer 側クリーチャーが盤上に存在しないときでも、勝利ではない', function() {
+        const battleFieldMatrix = createBattleFieldMatrix(1, 1)
+        assert.strictEqual(
+          doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber),
+          false
+        )
+      })
+    })
+  })
+
+  describe('doesPlayerHaveDefeat', function() {
+    it('works', function() {
+      assert.strictEqual(doesPlayerHaveDefeat(0), true)
+      assert.strictEqual(doesPlayerHaveDefeat(1), false)
+    })
+  })
+
   describe('removeDeadCreatures', function() {
     let creatures: Creature[]
     let battleFieldMatrix: BattleFieldMatrix

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -15,6 +15,7 @@ import {
   NormalAttackProcessContext,
   Party,
   SkillProcessContext,
+  VictoryOrDefeatId,
   determineRelationshipBetweenFactions,
   findCreatureAppearanceByTurnNumber,
   findCreatureById,
@@ -55,6 +56,20 @@ export function doesPlayerHaveVictory(
 
 export function doesPlayerHaveDefeat(headquartersLifePoint: Game['headquartersLifePoint']): boolean {
   return headquartersLifePoint === 0
+}
+
+export function determineVictoryOrDefeat(
+  parties: Party[],
+  battleFieldMatrix: BattleFieldMatrix,
+  creatureAppearances: CreatureAppearance[],
+  currentTurnNumber: Game['turnNumber'],
+  headquartersLifePoint: Game['headquartersLifePoint']
+): VictoryOrDefeatId {
+  return doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber)
+    ? 'victory'
+    : doesPlayerHaveDefeat(headquartersLifePoint)
+      ? 'defeat'
+      : 'pending'
 }
 
 export function placePlayerFactionCreature(

--- a/src/reducers/game.ts
+++ b/src/reducers/game.ts
@@ -22,12 +22,39 @@ import {
   findBattleFieldElementByCreatureId,
   findBattleFieldElementsByDistance,
   findCreatureWithParty,
+  findPartyByCreatureId,
   pickBattleFieldElementsWhereCreatureExists,
 } from '../utils';
 
 export const creatureUtils = {
   canAct: (creature: Creature): boolean => !creatureUtils.isDead(creature),
   isDead: (creature: Creature): boolean => creature.lifePoint === 0,
+}
+
+export function doesPlayerHaveVictory(
+  parties: Party[],
+  battleFieldMatrix: BattleFieldMatrix,
+  creatureAppearances: CreatureAppearance[],
+  currentTurnNumber: Game['turnNumber']
+): boolean {
+  return (
+    creatureAppearances.filter(e => e.turnNumber > currentTurnNumber).length === 0 &&
+    battleFieldMatrix.every(row => {
+      return row.every(element => {
+        return (
+          element.reservedCreatureId === undefined &&
+          (
+            element.creatureId === undefined ||
+            findPartyByCreatureId(parties, element.creatureId).factionId === 'player'
+          )
+        )
+      })
+    })
+  )
+}
+
+export function doesPlayerHaveDefeat(headquartersLifePoint: Game['headquartersLifePoint']): boolean {
+  return headquartersLifePoint === 0
 }
 
 export function placePlayerFactionCreature(

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -65,8 +65,17 @@ export function selectBattleFieldElement(
         ? findCardUnderCursor(draft.game.cards, draft.game.cursor)
         : undefined
 
-      // 通常攻撃フェーズ完了前、かつ、手札のカードへカーソルが当たっているとき。
-      if (draft.game.completedNormalAttackPhase === false && cardUnderCursor) {
+      // カードの使用（クリーチャーの配置・スキルの使用）をする。
+      //
+      // 勝敗決定前、または、通常攻撃フェーズ完了前、
+      // かつ、手札のカードへカーソルが当たっているとき。
+      if (
+        (
+          draft.game.battleResult.victoryOrDefeatId === 'pending' &&
+          draft.game.completedNormalAttackPhase === false
+        ) &&
+        cardUnderCursor
+      ) {
         // 選択先のマスへクリーチャーが配置されているとき。
         if (placedCreatureWithParty) {
           // 選択先クリーチャーがプレイヤー側のとき。
@@ -135,8 +144,9 @@ export function selectBattleFieldElement(
           // カーソルを外す。
           draft.game.cursor = undefined
         }
-      // 通常攻撃フェーズ完了後、または、手札のカードへカーソルが当たっていないとき。
+      // カードの使用、ができないとき。
       } else {
+        // カーソルをマスの選択へ変更する。
         draft.game.cursor = {
           globalPosition: {
             globalPlacementId: 'battleFieldMatrix',

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -24,6 +24,7 @@ import {
 } from '../utils'
 import {
   creatureUtils,
+  determineVictoryOrDefeat,
   invokeSkill,
   invokeNormalAttack,
   placePlayerFactionCreature,
@@ -289,6 +290,15 @@ export function proceedTurn(
       ...draft.game,
       ...refillCardsOnPlayersHand(draft.game.cardsInDeck, draft.game.cardsOnPlayersHand),
     }
+
+    // 勝敗判定をする。
+    draft.game.battleResult.victoryOrDefeatId = determineVictoryOrDefeat(
+      draft.game.parties,
+      draft.game.battleFieldMatrix,
+      draft.game.creatureAppearances,
+      draft.game.turnNumber,
+      draft.game.headquartersLifePoint
+    )
 
     draft.game.completedNormalAttackPhase = false
     draft.game.turnNumber += 1

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -97,6 +97,9 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           cursor: undefined,
           completedNormalAttackPhase: false,
           turnNumber: 1,
+          battleResult: {
+            victoryOrDefeatId: 'pending',
+          },
           headquartersLifePoint: 1,
         },
       },

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -97,6 +97,7 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           cursor: undefined,
           completedNormalAttackPhase: false,
           turnNumber: 1,
+          headquartersLifePoint: 1,
         },
       },
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,6 +100,12 @@ type Cursor = {
   globalPosition: GlobalPosition,
 }
 
+type VictoryOrDefeatId = 'victory' | 'defeat' | 'pending'
+
+export type BattleResult = {
+  victoryOrDefeatId: VictoryOrDefeatId,
+}
+
 export type NormalAttackProcessContext = {
   attackerCreatureId: Creature['id'],
   battleFieldMatrix: BattleFieldMatrix,
@@ -117,6 +123,7 @@ export type SkillProcessContext = {
 
 export type Game = {
   battleFieldMatrix: BattleFieldMatrix,
+  battleResult: BattleResult,
   cardsInDeck: CardRelationship[],
   cardsOnPlayersHand: CardRelationship[],
   cards: Card[],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -242,6 +242,15 @@ export function findCreatureWithParty(
   throw new Error('Can not find the `creatureId` from `parties`.')
 }
 
+export function findPartyByCreatureId(parties: Party[], creatureId: Creature['id']): Party {
+  for (const party of parties) {
+    if (party.creatureIds.indexOf(creatureId) !== -1) {
+      return party
+    }
+  }
+  throw new Error('Can not find the `creatureId` in parties.')
+}
+
 export function createBattleFieldMatrix(rowLength: number, columnLength: number): BattleFieldMatrix {
   const battleFieldMatrix: BattleFieldMatrix = []
   for (let y = 0; y < rowLength; y++) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,6 +124,7 @@ export type Game = {
   creatureAppearances: CreatureAppearance[],
   creatures: Creature[],
   cursor: Cursor | undefined,
+  headquartersLifePoint: number,
   parties: Party[],
   turnNumber: number,
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,7 +100,7 @@ type Cursor = {
   globalPosition: GlobalPosition,
 }
 
-type VictoryOrDefeatId = 'victory' | 'defeat' | 'pending'
+export type VictoryOrDefeatId = 'victory' | 'defeat' | 'pending'
 
 export type BattleResult = {
   victoryOrDefeatId: VictoryOrDefeatId,


### PR DESCRIPTION
- [x] 勝敗判定を作る。
  - [x] プレイヤーが勝利できるようにする。
    - [x] 勝利判定を作る。
    - [x] ~~勝利ならそのことを表示する。~~ 進行ボタンの文言変更で暫定的に対応。
  - [x] プレイヤーが敗北できるようにする。
    - [x] 敗北判定を作る。
      - [x] 本拠地ライフポイントが 0 になったら敗北する。
        - [x] 本拠地ライフポイントを定義する。
    - [x] ~~敗北ならそのことを表示する。~~ 進行ボタンの文言変更で暫定的に対応。
  - [x] 勝敗判定後はカードの使用をできなくする。
  - [x] 勝敗判定後は進行ボタンの文言を勝敗を示すものに暫定的に変更する。