### PR TITLE
AP

### DIFF
--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -9,6 +9,7 @@ import {
   createCreature,
   createConstants,
   createJob,
+  createStateDisplayBattlePageAtStartOfGame,
 } from '../test-utils';
 import {
   BattleFieldElement,
@@ -22,12 +23,14 @@ import {
   choiceElementsAtRandom,
   createBattleFieldMatrix,
   creatureUtils,
+  ensureBattlePage,
   findBattleFieldElementByCreatureId,
   findBattleFieldElementsByDistance,
   findCardUnderCursor,
   findCardsByCreatureIds,
   findPartyByCreatureId,
   flattenMatrix,
+  gameParameterUtils,
   measureDistance,
   pickBattleFieldElementsWhereCreatureExists,
   shuffleArray,
@@ -593,6 +596,28 @@ describe('utils', function() {
       it('raidCharge が raidInterval より小さいときは 1 を加算する', function() {
         creature.raidCharge = 2
         assert.strictEqual(creatureUtils.updateRaidChargeWithTurnProgress(creature, constants).raidCharge, 3)
+      })
+    })
+  })
+
+  describe('gameParameterUtils', function() {
+    let game: Game
+
+    beforeEach(function() {
+      game = ensureBattlePage(createStateDisplayBattlePageAtStartOfGame()).game
+    })
+
+    describe('alterActionPoints', function() {
+      it('actionPoints は 0 未満にならない', function() {
+        game.actionPoints = 1
+        game = gameParameterUtils.alterActionPoints(game, -2)
+        assert.strictEqual(game.actionPoints, 0)
+      })
+
+      it('actionPoints は 99 を超えない', function() {
+        game.actionPoints = 98
+        game = gameParameterUtils.alterActionPoints(game, 2)
+        assert.strictEqual(game.actionPoints, 99)
       })
     })
   })

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -307,6 +307,7 @@ const CardsOnPlayersHand: React.FC<CardsOnPlayersHandProps> = (props) => {
 }
 
 type FooterProps = {
+  actionPoints: number,
   progressButton: {
     label: string,
     handleTouch: () => void,
@@ -356,7 +357,7 @@ const Footer: React.FC<FooterProps> = (props) => {
         fontSize: '32px',
         backgroundColor: 'silver',
       }}>
-        <div>5</div>
+        <div>{props.actionPoints}</div>
       </div>
       <div
         style={rightSideButtonStyle}
@@ -373,6 +374,7 @@ const Footer: React.FC<FooterProps> = (props) => {
 }
 
 export type Props = {
+  actionPoints: FooterProps['actionPoints'],
   battleFieldBoard: {
     board: BattleFieldElementProps[][],
     handleTouch: BattleFieldBoardProps['handleTouch'],
@@ -402,6 +404,7 @@ export const BattlePage: React.FC<Props> = (props) => {
       <SquareMonitor />
       <CardsOnPlayersHand {...props.cardsOnPlayersHand} />
       <Footer
+        actionPoints={props.actionPoints}
         progressButton={props.progressButton}
       />
     </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,8 @@ function createInitialGame(): Game {
     battleResult: {
       victoryOrDefeatId: 'pending',
     },
-    actionPoints: 3,
+    actionPoints: 2,
+    actionPointsRecovery: 3,
     headquartersLifePoints: 10,
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,7 @@ function createInitialGame(): Game {
     battleResult: {
       victoryOrDefeatId: 'pending',
     },
+    actionPoints: 3,
     headquartersLifePoints: 10,
   }
 

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -155,6 +155,7 @@ function mapBattlePageStateToProps(
       cards: cardsProps
     },
     headquartersLifePoints: game.headquartersLifePoints,
+    actionPoints: game.actionPoints,
     turnNumber: game.turnNumber,
     progressButton,
   }

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -290,5 +290,13 @@ describe('reducers/index', function() {
       const newA = findCreatureById(newBattlePage.game.creatures, a.id)
       assert.strictEqual(newA.normalAttackInvoked, false)
     })
+
+    it('actionPoints を actionPointsRecovery の分回復する', function() {
+      battlePage.game.actionPoints = 2
+      battlePage.game.actionPointsRecovery = 3
+      const newState = proceedTurn(runNormalAttackPhase(state))
+      const newBattlePage = ensureBattlePage(newState)
+      assert.strictEqual(newBattlePage.game.actionPoints, 5)
+    })
   })
 })

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -22,6 +22,7 @@ import {
   findCardUnderCursor,
   findCreatureById,
   findCreatureWithParty,
+  gameParameterUtils,
   pickBattleFieldElementsWhereCreatureExists,
 } from '../utils'
 import {
@@ -363,6 +364,12 @@ export function proceedTurn(
       draft.game.creatureAppearances,
       draft.game.turnNumber,
       draft.game.headquartersLifePoints
+    )
+
+    // AP を回復する。
+    draft.game = gameParameterUtils.alterActionPoints(
+      draft.game,
+      gameParameterUtils.getActionPointsRecovery(draft.game)
     )
 
     draft.game.completedNormalAttackPhase = false

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -1,6 +1,8 @@
 import produce from 'immer'
 
 import {
+  ACTION_POINTS_REQUIRED_FOR_CREATURE_PLACEMENT,
+  ACTION_POINTS_REQUIRED_FOR_SKILL_USE,
   ApplicationState,
   BattleFieldElement,
   BattlePage,
@@ -81,8 +83,11 @@ export function selectBattleFieldElement(
         if (placedCreatureWithParty) {
           // 選択先クリーチャーがプレイヤー側のとき。
           if (placedCreatureWithParty.party.factionId === 'player') {
-            // 行動可能なとき。
-            if (creatureUtils.canAct(placedCreatureWithParty.creature)) {
+            // AP が 1 以上のとき、または、行動可能なとき。
+            if (
+              draft.game.actionPoints >= ACTION_POINTS_REQUIRED_FOR_SKILL_USE &&
+              creatureUtils.canAct(placedCreatureWithParty.creature)
+            ) {
               // スキルを発動する。
               draft.game = {
                 ...draft.game,
@@ -120,9 +125,11 @@ export function selectBattleFieldElement(
                 ),
               }
 
+              // AP を 1 消費する。
+              draft.game.actionPoints -= ACTION_POINTS_REQUIRED_FOR_SKILL_USE
               // カーソルを外す。
               draft.game.cursor = undefined
-            // 行動不能なとき。
+            // AP が 1 未満のとき、または、行動不能なとき。
             } else {
               /* no-op */
             }
@@ -132,19 +139,24 @@ export function selectBattleFieldElement(
           }
         // 選択先のマスへクリーチャーが配置されていないとき。
         } else {
-          // クリーチャーを配置する。
-          // 手札からそのクリーチャーのカードを削除する。
-          draft.game = {
-            ...draft.game,
-            ...placePlayerFactionCreature(
-              draft.game.battleFieldMatrix,
-              draft.game.cardsOnPlayersHand,
-              cardUnderCursor.creatureId,
-              battleFieldElement.position
-            ),
+          // AP が 2 以上のとき。
+          if (draft.game.actionPoints >= ACTION_POINTS_REQUIRED_FOR_CREATURE_PLACEMENT) {
+            // クリーチャーを配置する。
+            // 手札からそのクリーチャーのカードを削除する。
+            draft.game = {
+              ...draft.game,
+              ...placePlayerFactionCreature(
+                draft.game.battleFieldMatrix,
+                draft.game.cardsOnPlayersHand,
+                cardUnderCursor.creatureId,
+                battleFieldElement.position
+              ),
+            }
+            // AP を 2 消費する。
+            draft.game.actionPoints -= ACTION_POINTS_REQUIRED_FOR_CREATURE_PLACEMENT
+            // カーソルを外す。
+            draft.game.cursor = undefined
           }
-          // カーソルを外す。
-          draft.game.cursor = undefined
         }
       // カードの使用、ができないとき。
       } else {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -125,7 +125,8 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           battleResult: {
             victoryOrDefeatId: 'pending',
           },
-          actionPoints: 3,
+          actionPoints: 2,
+          actionPointsRecovery: 3,
           headquartersLifePoints: 1,
         },
       },

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -125,6 +125,7 @@ export function createStateDisplayBattlePageAtStartOfGame(): ApplicationState {
           battleResult: {
             victoryOrDefeatId: 'pending',
           },
+          actionPoints: 3,
           headquartersLifePoints: 1,
         },
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,6 +149,8 @@ export type ApplicationState = {
 }
 
 export const MAX_NUMBER_OF_PLAYERS_HAND = 5
+export const ACTION_POINTS_REQUIRED_FOR_CREATURE_PLACEMENT = 2
+export const ACTION_POINTS_REQUIRED_FOR_SKILL_USE = 1
 
 /**
  * Shuffle an array with the Fisher–Yates algorithm.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -445,3 +445,15 @@ export const creatureUtils = {
     return creatureUtils.alterRaidCharge(creature, constants, delta)
   },
 }
+
+export const gameParameterUtils = {
+  getActionPointsRecovery: (game: Game): number => {
+    return game.actionPointsRecovery
+  },
+  alterActionPoints: (game: Game, delta: number): Game => {
+    return {
+      ...game,
+      actionPoints: Math.min(Math.max(game.actionPoints + delta, 0), 99),
+    }
+  },
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -120,6 +120,7 @@ export type BattleResult = {
 }
 
 export type Game = {
+  actionPoints: number,
   battleFieldMatrix: BattleFieldMatrix,
   battleResult: BattleResult,
   cardsInDeck: CardRelationship[],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,6 +121,7 @@ export type BattleResult = {
 
 export type Game = {
   actionPoints: number,
+  actionPointsRecovery: number,
   battleFieldMatrix: BattleFieldMatrix,
   battleResult: BattleResult,
   cardsInDeck: CardRelationship[],


### PR DESCRIPTION
- [x] カード使用時にAP(Action Points)を消費する。
  - [x] AP を表示する。
  - [x] カードをクリーチャー配置に使用した場合は AP を 2 消費する。
  - [x] カードをスキル発動に使用した場合は AP を 1 消費する。
  - [x] AP が足りないときはカードを使用できない。
  - [x] AP をターン遷移時に 3 増加する。
    - [x] `gameParameterUtils.getActionPointsRecovery` を経由して値を取得する。
    - [x] 同様に AP を増加するときにも関数を介して行う。