### PR TITLE
Show auto-attack range

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "develop": "$(npm bin)/webpack-dev-server --config webpack-configs/development.js",
-    "test": "$(npm bin)/mocha --require 'ts-node-reigister.js' --recursive 'src/**/__tests__/**/*-test.ts'",
+    "test": "$(npm bin)/mocha --require 'setup-mocha-runner.js' --recursive 'src/**/__tests__/**/*-test.ts'",
     "typecheck": "$(npm bin)/tsc --noEmit"
   },
   "repository": {

--- a/setup-mocha-runner.js
+++ b/setup-mocha-runner.js
@@ -1,0 +1,5 @@
+require('immer').setAutoFreeze(false)
+
+require('ts-node').register({
+  files: true,
+})

--- a/src/__tests__/map-state-to-props-test.ts
+++ b/src/__tests__/map-state-to-props-test.ts
@@ -1,0 +1,124 @@
+import * as assert from 'assert'
+import {
+  beforeEach,
+  describe,
+  it,
+} from 'mocha'
+
+import {
+  ReactSetState,
+  mapStateToProps,
+} from '../map-state-to-props'
+import {
+  ApplicationState,
+  BattlePage,
+  Creature,
+  ensureBattlePage,
+  findCreatureById,
+} from '../utils'
+import {
+  createStateDisplayBattlePageAtStartOfGame,
+  findFirstAlly,
+  ensureBattlePageProps,
+} from '../test-utils'
+import {
+  selectBattleFieldElement,
+} from '../reducers/index'
+import {
+  placePlayerFactionCreature,
+} from '../reducers/utils'
+
+describe('map-state-to-props', function() {
+  const dummySetState = (() => {}) as ReactSetState
+
+  describe('pages.battlePage', function() {
+    let state: ApplicationState
+    let battlePage: BattlePage
+
+    beforeEach(function() {
+      state = createStateDisplayBattlePageAtStartOfGame()
+      battlePage = ensureBattlePage(state)
+    })
+
+    describe('選択したクリーチャーの自動攻撃範囲・対象・優先順位の表示', function() {
+      describe('近接範囲を持つ player のクリーチャーへカーソルが当たっているとき', function() {
+        let attacker: Creature
+
+        beforeEach(function() {
+          attacker = findCreatureById(battlePage.game.creatures, battlePage.game.cardsOnPlayersHand[0].creatureId)
+          battlePage.game = {
+            ...battlePage.game,
+            ...placePlayerFactionCreature(
+              battlePage.game.creatures,
+              battlePage.game.battleFieldMatrix,
+              battlePage.game.cardsOnPlayersHand,
+              attacker.id,
+              {y: 1, x: 1}
+            )
+          }
+          state = selectBattleFieldElement(state, 1, 1)
+          battlePage = ensureBattlePage(state)
+        })
+
+        it('隣接している上下左右のマスの isWithinRange が true である', function() {
+          const battlePageProps = ensureBattlePageProps(mapStateToProps(state, dummySetState))
+          const board = battlePageProps.battleFieldBoard.board
+          assert.strictEqual(board[0][1].isWithinRange, true)
+          assert.strictEqual(board[1][0].isWithinRange, true)
+          assert.strictEqual(board[1][2].isWithinRange, true)
+          assert.strictEqual(board[2][1].isWithinRange, true)
+        })
+
+        it('隣接していないマスの isWithinRange は false である', function() {
+          const battlePageProps = ensureBattlePageProps(mapStateToProps(state, dummySetState))
+          const board = battlePageProps.battleFieldBoard.board
+          assert.strictEqual(board[0][0].isWithinRange, false)
+        })
+
+        describe('1 体の味方と 1 体の敵に隣接しているとき', function() {
+          beforeEach(function() {
+            const ally = findCreatureById(
+              battlePage.game.creatures, battlePage.game.cardsOnPlayersHand[1].creatureId)
+            battlePage.game = {
+              ...battlePage.game,
+              ...placePlayerFactionCreature(
+                battlePage.game.creatures,
+                battlePage.game.battleFieldMatrix,
+                battlePage.game.cardsOnPlayersHand,
+                ally.id,
+                {y: 0, x: 1}
+              )
+            }
+            const enemy = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'computer')
+            battlePage.game.battleFieldMatrix[1][0].creatureId = enemy.id
+            // TODO: 配置順と同期する必要があるため、敵の配置処理も関数化が必要
+            const newAlly = findCreatureById(battlePage.game.creatures, ally.id)
+            enemy.placementOrder = newAlly.placementOrder + 1
+          })
+
+          it('味方が存在しているマスは isTarget=false, targetPriority=undefined である', function() {
+            const battlePageProps = ensureBattlePageProps(mapStateToProps(state, dummySetState))
+            const board = battlePageProps.battleFieldBoard.board
+            assert.strictEqual(board[0][1].isTarget, false)
+            assert.strictEqual(board[0][1].targetPriority, undefined)
+          })
+
+          it('敵が存在しているマスは isTarget=true, targetPriority=1 である', function() {
+            const battlePageProps = ensureBattlePageProps(mapStateToProps(state, dummySetState))
+            const board = battlePageProps.battleFieldBoard.board
+            assert.strictEqual(board[1][0].isTarget, true)
+            assert.strictEqual(board[1][0].targetPriority, 1)
+          })
+
+          it('範囲内で敵が存在していないマスは isTarget=false, targetPriority=undefined, isWithinRange=true である', function() {
+            const battlePageProps = ensureBattlePageProps(mapStateToProps(state, dummySetState))
+            const board = battlePageProps.battleFieldBoard.board
+            assert.strictEqual(board[1][2].isTarget, false)
+            assert.strictEqual(board[1][2].targetPriority, undefined)
+            assert.strictEqual(board[1][2].isWithinRange, true)
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -609,9 +609,9 @@ describe('utils', function() {
     })
 
     describe('getAutoAttackTargets', function() {
-      it('_autoAttackTargets が存在しているときはその値を優先して返す', function() {
+      it('_autoAttackTargetsForTest が存在しているときはその値を優先して返す', function() {
         constants.jobs[0].autoAttackTargets = 1
-        creature._autoAttackTargets = 2
+        creature._autoAttackTargetsForTest = 2
         assert.strictEqual(creatureUtils.getAutoAttackTargets(creature, constants), 2)
       })
     })

--- a/src/__tests__/utils-test.ts
+++ b/src/__tests__/utils-test.ts
@@ -608,6 +608,14 @@ describe('utils', function() {
       })
     })
 
+    describe('getAutoAttackTargets', function() {
+      it('_autoAttackTargets が存在しているときはその値を優先して返す', function() {
+        constants.jobs[0].autoAttackTargets = 1
+        creature._autoAttackTargets = 2
+        assert.strictEqual(creatureUtils.getAutoAttackTargets(creature, constants), 2)
+      })
+    })
+
     describe('getMaxLifePoints', function() {
       it('_maxLifePointsForTest が存在しているときはその値を優先して返す', function() {
         constants.jobs[0].maxLifePoints = 2

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -116,6 +116,7 @@ const CreatureOnElement: React.FC<CreatureOnElementProps> = (props) => {
 type BattleFieldElementProps = {
   creature: CreatureOnElementProps | void,
   isSelected: boolean,
+  isTarget: boolean,
   isWithinRange: boolean,
   x: number,
   y: number,
@@ -140,8 +141,8 @@ const BattleFieldElement: React.FC<BattleFieldElementProps> = (props) => {
           left: '0',
           width: '48px',
           height: '48px',
-          backgroundColor: props.isWithinRange ? 'yellow' : '',
-          opacity: 0.5,
+          border: props.isTarget ? '2px solid white' : '',
+          backgroundColor: props.isWithinRange ? 'rgba(255, 255, 0, .5)' : '',
         }}
       />
       {

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -116,25 +116,37 @@ const CreatureOnElement: React.FC<CreatureOnElementProps> = (props) => {
 type BattleFieldElementProps = {
   creature: CreatureOnElementProps | void,
   isSelected: boolean,
+  isWithinRange: boolean,
   x: number,
   y: number,
 }
 
 const BattleFieldElement: React.FC<BattleFieldElementProps> = (props) => {
-  const style = {
-    position: 'absolute',
-    top: `${6 + props.y * 48 + props.y * 2}px`,
-    left: `${6 + props.x * 48 + props.x * 2}px`,
-    width: '48px',
-    height: '48px',
-    backgroundColor: props.isSelected ? 'yellow' : 'lime',
-  }
-
   return (
-    <div style={style}>
-    {
-      props.creature ? <CreatureOnElement {...props.creature} /> : undefined
-    }
+    <div
+      style={{
+        position: 'absolute',
+        top: `${6 + props.y * 48 + props.y * 2}px`,
+        left: `${6 + props.x * 48 + props.x * 2}px`,
+        width: '48px',
+        height: '48px',
+        backgroundColor: props.isSelected ? 'yellow' : 'lime',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: '0',
+          left: '0',
+          width: '48px',
+          height: '48px',
+          backgroundColor: props.isWithinRange ? 'yellow' : '',
+          opacity: 0.5,
+        }}
+      />
+      {
+        props.creature ? <CreatureOnElement {...props.creature} /> : undefined
+      }
     </div>
   )
 }

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -116,8 +116,10 @@ const CreatureOnElement: React.FC<CreatureOnElementProps> = (props) => {
 type BattleFieldElementProps = {
   creature: CreatureOnElementProps | void,
   isSelected: boolean,
+  // TODO: 対象かと優先順位が見辛すぎるので改善する。
   isTarget: boolean,
   isWithinRange: boolean,
+  targetPriority: number | undefined,
   x: number,
   y: number,
 }
@@ -144,7 +146,26 @@ const BattleFieldElement: React.FC<BattleFieldElementProps> = (props) => {
           border: props.isTarget ? '2px solid white' : '',
           backgroundColor: props.isWithinRange ? 'rgba(255, 255, 0, .5)' : '',
         }}
-      />
+      >
+        {
+          props.targetPriority !== undefined
+            ? <div
+              style={{
+                position: 'absolute',
+                top: '0',
+                left: '0',
+                width: '48px',
+                height: '48px',
+                lineHeight: '48px',
+                fontSize: '24px',
+                fontWeight: 'bold',
+                textAlign: 'center',
+                color: 'white',
+              }}
+            >{props.targetPriority}</div>
+            : null
+        }
+      </div>
       {
         props.creature ? <CreatureOnElement {...props.creature} /> : undefined
       }

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -136,36 +136,51 @@ const BattleFieldElement: React.FC<BattleFieldElementProps> = (props) => {
         backgroundColor: props.isSelected ? 'yellow' : 'lime',
       }}
     >
-      <div
-        style={{
-          position: 'absolute',
-          top: '0',
-          left: '0',
-          width: '48px',
-          height: '48px',
-          border: props.isTarget ? '2px solid white' : '',
-          backgroundColor: props.isWithinRange ? 'rgba(255, 255, 0, .5)' : '',
-        }}
-      >
-        {
-          props.targetPriority !== undefined
-            ? <div
-              style={{
-                position: 'absolute',
-                top: '0',
-                left: '0',
-                width: '48px',
-                height: '48px',
-                lineHeight: '48px',
-                fontSize: '24px',
-                fontWeight: 'bold',
-                textAlign: 'center',
-                color: 'white',
-              }}
-            >{props.targetPriority}</div>
-            : null
-        }
-      </div>
+      {
+        props.isTarget && <div
+          style={{
+            position: 'absolute',
+            top: '0',
+            left: '0',
+            width: '48px',
+            height: '48px',
+            border: '2px solid white',
+            zIndex: 2,
+          }}
+        >
+          {
+            props.targetPriority !== undefined
+              ? <div
+                style={{
+                  position: 'absolute',
+                  top: '0',
+                  left: '0',
+                  width: '48px',
+                  height: '48px',
+                  lineHeight: '48px',
+                  fontSize: '24px',
+                  fontWeight: 'bold',
+                  textAlign: 'center',
+                  color: 'white',
+                }}
+              >{props.targetPriority}</div>
+              : null
+          }
+        </div>
+      }
+      {
+        props.isWithinRange && <div
+          style={{
+            position: 'absolute',
+            top: '0',
+            left: '0',
+            width: '48px',
+            height: '48px',
+            backgroundColor: 'rgba(255, 255, 0, .5)',
+            zIndex: 1,
+          }}
+        />
+      }
       {
         props.creature ? <CreatureOnElement {...props.creature} /> : undefined
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,11 @@ const dummyJobs: Job[] = [
     id: 'archer',
     maxLifePoints: 6,
     attackPower: 3,
+    autoAttackRange: {
+      rangeShapeKey: 'circle',
+      minReach: 1,
+      maxReach: 2,
+    },
   },
   {
     ...dummyJobTemplate,
@@ -56,6 +61,17 @@ const dummyJobs: Job[] = [
   },
   {
     ...dummyJobTemplate,
+    id: 'gunner',
+    maxLifePoints: 6,
+    attackPower: 3,
+    autoAttackRange: {
+      rangeShapeKey: 'cross',
+      minReach: 1,
+      maxReach: 3,
+    },
+  },
+  {
+    ...dummyJobTemplate,
     id: 'knight',
     maxLifePoints: 18,
     attackPower: 2,
@@ -64,7 +80,12 @@ const dummyJobs: Job[] = [
     ...dummyJobTemplate,
     id: 'mage',
     maxLifePoints: 3,
-    attackPower: 3,
+    attackPower: 2,
+    autoAttackRange: {
+      rangeShapeKey: 'circle',
+      minReach: 1,
+      maxReach: 2,
+    },
   },
   {
     ...dummyJobTemplate,
@@ -90,7 +111,7 @@ const dummyAllies: Creature[] = Array.from({length: 20}).map((unused, index) => 
     skillIds: [],
     autoAttackInvoked: false,
   }
-  switch (index % 5) {
+  switch (index % 6) {
     case 0:
       return {
         ...dummyAllyTemplate,
@@ -115,6 +136,11 @@ const dummyAllies: Creature[] = Array.from({length: 20}).map((unused, index) => 
       return {
         ...dummyAllyTemplate,
         jobId: 'priest',
+      }
+    case 5:
+      return {
+        ...dummyAllyTemplate,
+        jobId: 'gunner',
       }
     default:
       throw new Error('')

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ const dummyJobs: Job[] = [
       minReach: 1,
       maxReach: 2,
     },
+    autoAttackTargets: 99,
   },
   {
     ...dummyJobTemplate,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import {setAutoFreeze} from 'immer'
 import * as React from 'react'
 import * as ReactDOM from 'react-dom'
 
@@ -21,6 +22,8 @@ import {
 import {
   initializeGame,
 } from './reducers/utils'
+
+setAutoFreeze(false)
 
 const dummyJobTemplate = {
   id: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ const dummyJobTemplate = {
     minReach: 1,
     maxReach: 1,
   },
+  autoAttackTargets: 1,
 }
 const dummyJobs: Job[] = [
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,7 @@ const dummyAllies: Creature[] = Array.from({length: 20}).map((unused, index) => 
     raidCharge: 0,
     skillIds: [],
     autoAttackInvoked: false,
+    placementOrder: 0,
   }
   switch (index % 6) {
     case 0:
@@ -154,6 +155,7 @@ const dummyEnemies: Creature[] = Array.from({length: 20}).map((unused, index) =>
     raidCharge: 0,
     skillIds: [],
     autoAttackInvoked: false,
+    placementOrder: 0,
   }
   switch (index % 2) {
     case 0:

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   Creature,
   Game,
   Job,
+  DEFAULT_PLACEMENT_ORDER,
   MAX_NUMBER_OF_PLAYERS_HAND,
   Party,
   SkillCategoryId,
@@ -110,7 +111,7 @@ const dummyAllies: Creature[] = Array.from({length: 20}).map((unused, index) => 
     raidCharge: 0,
     skillIds: [],
     autoAttackInvoked: false,
-    placementOrder: 0,
+    placementOrder: DEFAULT_PLACEMENT_ORDER,
   }
   switch (index % 6) {
     case 0:
@@ -155,7 +156,7 @@ const dummyEnemies: Creature[] = Array.from({length: 20}).map((unused, index) =>
     raidCharge: 0,
     skillIds: [],
     autoAttackInvoked: false,
-    placementOrder: 0,
+    placementOrder: DEFAULT_PLACEMENT_ORDER,
   }
   switch (index % 2) {
     case 0:

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -91,6 +91,7 @@ function mapBattlePageStateToProps(
         isSelected: game.cursor
           ? areGlobalPositionsEqual(element.globalPosition, game.cursor.globalPosition)
           : false,
+        isWithinRange: false,
       }
     })
   })

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -32,7 +32,7 @@ import {
   selectCardOnPlayersHand,
 } from './reducers'
 
-type ReactSetState = React.Dispatch<React.SetStateAction<ApplicationState>>
+export type ReactSetState = React.Dispatch<React.SetStateAction<ApplicationState>>
 
 const jobIdToDummyImage = (jobId: string): string => {
   const mapping: {
@@ -127,16 +127,23 @@ function mapBattlePageStateToProps(
       range.minReach,
       range.maxReach
     )
-    // そのマスリスト内のクリーチャーリストを取得し、攻撃対象の優先順位が高い順に整列する。
+    // そのマスリスト内の敵対クリーチャーリストを取得する。
     let attackees: CreatureWithPartyOnBattleFieldElement[] = []
     for (const element of rangedElements) {
       if (element.creatureId !== undefined) {
         const creatureWithParty = findCreatureWithParty(game.creatures, game.parties, element.creatureId)
-        attackees.push({
-          creature: creatureWithParty.creature,
-          party: creatureWithParty.party,
-          battleFieldElement: element,
-        })
+        if (
+          determineRelationshipBetweenFactions(
+            cursoredElement.creatureWithParty.party.factionId,
+            creatureWithParty.party.factionId
+          ) === 'enemy'
+        ) {
+          attackees.push({
+            creature: creatureWithParty.creature,
+            party: creatureWithParty.party,
+            battleFieldElement: element,
+          })
+        }
       }
     }
     // TODO: invokeAutoAttack 内の同じロジックと共通化する。攻撃対象数・優先順位判定など。
@@ -160,7 +167,7 @@ function mapBattlePageStateToProps(
       const attackee = attackees[i]
       const element = attackee.battleFieldElement
       boardProps[element.position.y][element.position.x].isTarget = true
-      boardProps[element.position.y][element.position.x].targetPriority = i + 1 
+      boardProps[element.position.y][element.position.x].targetPriority = i + 1
     }
   }
 

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -108,6 +108,7 @@ function mapBattlePageStateToProps(
         creature: creatureProps,
         isSelected,
         isWithinRange: false,
+        isTarget: false,
       }
     })
   })

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -40,6 +40,7 @@ const jobIdToDummyImage = (jobId: string): string => {
     archer: '弓',
     fighter: '戦',
     goblin: 'ゴ',
+    gunner: '銃',
     knight: '重',
     mage: '魔',
     priest: '聖',

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -9,6 +9,7 @@ import {
   ApplicationState,
   BattlePage,
   Creature,
+  DEFAULT_PLACEMENT_ORDER,
   Party,
   createBattleFieldMatrix,
   ensureBattlePage,
@@ -302,6 +303,14 @@ describe('reducers/index', function() {
       const newState = proceedTurn(runAutoAttackPhase(state))
       const newBattlePage = ensureBattlePage(newState)
       assert.strictEqual(newBattlePage.game.actionPoints, 5)
+    })
+
+    it('配置されていないクリーチャーの配置順は初期値と等しい', function() {
+      const newState = proceedTurn(runAutoAttackPhase(state))
+      const newBattlePage = ensureBattlePage(newState)
+      for (const newCreature of newBattlePage.game.creatures) {
+        assert.strictEqual(newCreature.placementOrder, DEFAULT_PLACEMENT_ORDER)
+      }
     })
   })
 })

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -106,6 +106,7 @@ describe('reducers/index', function() {
         battlePage.game = {
           ...battlePage.game,
           ...placePlayerFactionCreature(
+            battlePage.game.creatures,
             battlePage.game.battleFieldMatrix,
             battlePage.game.cardsOnPlayersHand,
             a.id,
@@ -159,6 +160,7 @@ describe('reducers/index', function() {
         battlePage.game = {
           ...battlePage.game,
           ...placePlayerFactionCreature(
+            battlePage.game.creatures,
             battlePage.game.battleFieldMatrix,
             battlePage.game.cardsOnPlayersHand,
             a.id,
@@ -168,6 +170,7 @@ describe('reducers/index', function() {
         battlePage.game = {
           ...battlePage.game,
           ...placePlayerFactionCreature(
+            battlePage.game.creatures,
             battlePage.game.battleFieldMatrix,
             battlePage.game.cardsOnPlayersHand,
             b.id,
@@ -196,6 +199,7 @@ describe('reducers/index', function() {
         battlePage.game = {
           ...battlePage.game,
           ...placePlayerFactionCreature(
+            battlePage.game.creatures,
             battlePage.game.battleFieldMatrix,
             battlePage.game.cardsOnPlayersHand,
             a.id,
@@ -234,6 +238,7 @@ describe('reducers/index', function() {
           battlePage.game = {
             ...battlePage.game,
             ...placePlayerFactionCreature(
+              battlePage.game.creatures,
               battlePage.game.battleFieldMatrix,
               battlePage.game.cardsOnPlayersHand,
               p.id,

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -276,7 +276,7 @@ describe('reducers/utils', function() {
         })
 
         it('攻撃者の攻撃対象数が 1 のとき、配置順が最も低い攻撃対象のみを攻撃する', function() {
-          attacker._autoAttackTargets = 1
+          attacker._autoAttackTargetsForTest = 1
           enemies[0].placementOrder = 2
           enemies[1].placementOrder = 1
           enemies[2].placementOrder = 3
@@ -294,7 +294,7 @@ describe('reducers/utils', function() {
         })
 
         it('攻撃者の攻撃対象数が複数のとき、配置順が低い順に複数の攻撃対象を攻撃する', function() {
-          attacker._autoAttackTargets = 2
+          attacker._autoAttackTargetsForTest = 2
           enemies[0].placementOrder = 2
           enemies[1].placementOrder = 1
           enemies[2].placementOrder = 3

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -322,31 +322,43 @@ describe('reducers/utils', function() {
   })
 
   describe('placePlayerFactionCreature', function() {
+    let a: Creature
+    let creatures: Creature[]
+    let matrix: BattleFieldMatrix
+
+    beforeEach(function() {
+      a = createCreature()
+      creatures = [a]
+      matrix = createBattleFieldMatrix(1, 1)
+    })
+
     it('指定したマスにクリーチャーが存在するとき、例外を発生する', function() {
-      const matrix = createBattleFieldMatrix(1, 1)
       matrix[0][0].creatureId = 'a'
       assert.throws(() => {
-        placePlayerFactionCreature(matrix, [], 'b', {y: 0, x: 0})
+        placePlayerFactionCreature(creatures, matrix, [], a.id, {y: 0, x: 0})
       }, /creature exist/)
     })
 
     it('指定したクリーチャーが手札にないとき、例外を発生する', function() {
-      const matrix = createBattleFieldMatrix(1, 1)
       assert.throws(() => {
-        placePlayerFactionCreature(matrix, [], 'a', {y: 0, x: 0})
+        placePlayerFactionCreature(creatures, matrix, [], 'foo', {y: 0, x: 0})
       }, /does not exist/)
     })
 
     it('盤上へクリーチャーが配置される', function() {
-      const matrix = createBattleFieldMatrix(1, 1)
-      const result = placePlayerFactionCreature(matrix, [{creatureId: 'a'}], 'a', {y: 0, x: 0})
-      assert.strictEqual(result.battleFieldMatrix[0][0].creatureId, 'a')
+      const result = placePlayerFactionCreature(creatures, matrix, [{creatureId: a.id}], a.id, {y: 0, x: 0})
+      assert.strictEqual(result.battleFieldMatrix[0][0].creatureId, a.id)
     })
 
     it('指定したクリーチャーのカードが手札から削除される', function() {
-      const matrix = createBattleFieldMatrix(1, 1)
-      const result = placePlayerFactionCreature(matrix, [{creatureId: 'a'}, {creatureId: 'b'}], 'a', {y: 0, x: 0})
-      assert.deepStrictEqual(result.cardsOnPlayersHand, [{creatureId: 'b'}])
+      const result = placePlayerFactionCreature(
+        creatures, matrix, [{creatureId: a.id}, {creatureId: 'foo'}], a.id, {y: 0, x: 0})
+      assert.deepStrictEqual(result.cardsOnPlayersHand, [{creatureId: 'foo'}])
+    })
+
+    it('指定したクリーチャーの配置順を増加する', function() {
+      const result = placePlayerFactionCreature(creatures, matrix, [{creatureId: a.id}], a.id, {y: 0, x: 0})
+      assert.strictEqual(result.creatures[0].placementOrder > a.placementOrder, true)
     })
   })
 

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -392,18 +392,43 @@ describe('reducers/utils', function() {
   })
 
   describe('reserveCreatures', function() {
-    it('works', function() {
-      const matrix = createBattleFieldMatrix(3, 3)
-      const creatureAppearances = [
+    let a: Creature
+    let b: Creature
+    let creatures: Creature[]
+    let matrix: BattleFieldMatrix
+    let creatureAppearances: CreatureAppearance[]
+
+    beforeEach(function() {
+      a = createCreature()
+      b = createCreature()
+      creatures = [a, b]
+      matrix = createBattleFieldMatrix(3, 3)
+      creatureAppearances = [
         {
           turnNumber: 2,
-          creatureIds: ['a', 'b'],
+          creatureIds: [a.id, b.id],
         }
       ]
-      const result = reserveCreatures(
-        matrix, creatureAppearances, 2, (elements, num) => elements.slice(0, num))
-      assert.strictEqual(result.battleFieldMatrix[0][0].reservedCreatureId, 'a')
-      assert.strictEqual(result.battleFieldMatrix[0][1].reservedCreatureId, 'b')
+    })
+
+    describe('出現が予約されているターン数を指定したとき', function() {
+      const turnNumber = 2
+
+      it('クリーチャーの出現を盤へ予約する', function() {
+        const result = reserveCreatures(
+          creatures, matrix, creatureAppearances, turnNumber, () => [matrix[0][0], matrix[0][1]])
+        assert.strictEqual(result.battleFieldMatrix[0][0].reservedCreatureId, a.id)
+        assert.strictEqual(result.battleFieldMatrix[0][1].reservedCreatureId, b.id)
+      })
+
+      it('クリーチャーの配置順を増加する', function() {
+        const result = reserveCreatures(
+          creatures, matrix, creatureAppearances, turnNumber, () => [matrix[0][0], matrix[0][1]])
+        const newA = findCreatureById(result.creatures, a.id)
+        const newB = findCreatureById(result.creatures, b.id)
+        assert.strictEqual(newA.placementOrder > a.placementOrder, true)
+        assert.strictEqual(newB.placementOrder > b.placementOrder, true)
+      })
     })
   })
 

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -275,8 +275,8 @@ describe('reducers/utils', function() {
           battlePage.game.battleFieldMatrix[1][2].creatureId = enemies[2].id
         })
 
-        // TODO: "攻撃者の攻撃対象数" の能力値ができたら、コンテキストとして設定する。
-        it('攻撃者の攻撃対象数が 1 のとき、配置順が低い方の攻撃対象のみを攻撃する', function() {
+        it('攻撃者の攻撃対象数が 1 のとき、配置順が最も低い攻撃対象のみを攻撃する', function() {
+          attacker._autoAttackTargets = 1
           enemies[0].placementOrder = 2
           enemies[1].placementOrder = 1
           enemies[2].placementOrder = 3
@@ -289,6 +289,24 @@ describe('reducers/utils', function() {
           )
           const newEnemies = enemies.map(e => findCreatureById(result.creatures, e.id))
           assert.strictEqual(newEnemies[0].lifePoints < 2, false)
+          assert.strictEqual(newEnemies[1].lifePoints < 2, true)
+          assert.strictEqual(newEnemies[2].lifePoints < 2, false)
+        })
+
+        it('攻撃者の攻撃対象数が複数のとき、配置順が低い順に複数の攻撃対象を攻撃する', function() {
+          attacker._autoAttackTargets = 2
+          enemies[0].placementOrder = 2
+          enemies[1].placementOrder = 1
+          enemies[2].placementOrder = 3
+          const result = invokeAutoAttack(
+            battlePage.game.constants,
+            battlePage.game.creatures,
+            battlePage.game.parties,
+            battlePage.game.battleFieldMatrix,
+            attacker.id,
+          )
+          const newEnemies = enemies.map(e => findCreatureById(result.creatures, e.id))
+          assert.strictEqual(newEnemies[0].lifePoints < 2, true)
           assert.strictEqual(newEnemies[1].lifePoints < 2, true)
           assert.strictEqual(newEnemies[2].lifePoints < 2, false)
         })

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -147,6 +147,7 @@ export function selectBattleFieldElement(
             draft.game = {
               ...draft.game,
               ...placePlayerFactionCreature(
+                draft.game.creatures,
                 draft.game.battleFieldMatrix,
                 draft.game.cardsOnPlayersHand,
                 cardUnderCursor.creatureId,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -343,6 +343,7 @@ export function proceedTurn(
     draft.game = {
       ...draft.game,
       ...reserveCreatures(
+        draft.game.creatures,
         draft.game.battleFieldMatrix,
         draft.game.creatureAppearances,
         draft.game.turnNumber,

--- a/src/reducers/utils.ts
+++ b/src/reducers/utils.ts
@@ -240,9 +240,13 @@ export function invokeAutoAttack(
     // 優先順位を考慮して攻撃対象を決定する。
     const targeteesData = targeteeCandidatesData
       .slice()
-      // TODO: Priority calculation
       .sort((a, b) => {
-        return -1
+        if (a.creature.placementOrder < b.creature.placementOrder) {
+          return -1
+        } else if (a.creature.placementOrder > b.creature.placementOrder) {
+          return 1
+        }
+        return 0
       })
       .slice(0, dummyMaxNumberOfTargetees)
 

--- a/src/reducers/utils.ts
+++ b/src/reducers/utils.ts
@@ -235,7 +235,7 @@ export function invokeAutoAttack(
   // 範囲内に攻撃対象がいたとき。
   if (targeteeCandidatesData.length > 0) {
     // 最大攻撃対象数を算出する。
-    const dummyMaxNumberOfTargetees = 1
+    const maxNumberOfTargetees = creatureUtils.getAutoAttackTargets(attackerData.creature, constants)
 
     // 優先順位を考慮して攻撃対象を決定する。
     const targeteesData = targeteeCandidatesData
@@ -248,7 +248,7 @@ export function invokeAutoAttack(
         }
         return 0
       })
-      .slice(0, dummyMaxNumberOfTargetees)
+      .slice(0, maxNumberOfTargetees)
 
     // 影響を決定する。
     // NOTE: このループ内で攻撃対象が死亡するなどしても、対象から除外しなくても良い。

--- a/src/reducers/utils.ts
+++ b/src/reducers/utils.ts
@@ -11,6 +11,7 @@ import {
   CreatureWithPartyOnBattleFieldElement,
   Game,
   Job,
+  DEFAULT_PLACEMENT_ORDER,
   MAX_NUMBER_OF_PLAYERS_HAND,
   MatrixPosition,
   Party,
@@ -85,6 +86,7 @@ export function determineVictoryOrDefeat(
 }
 
 export function placePlayerFactionCreature(
+  creatures: Creature[],
   battleFieldMatrix: BattleFieldMatrix,
   cardsOnPlayersHand: CardRelationship[],
   creatureId: Creature['id'],
@@ -92,6 +94,7 @@ export function placePlayerFactionCreature(
 ): {
   battleFieldMatrix: BattleFieldMatrix,
   cardsOnPlayersHand: CardRelationship[],
+  creatures: Creature[],
 } {
   const element = battleFieldMatrix[position.y][position.x]
   // NOTE: 欲しい仕様ではないが、今はこの状況にならないはず。
@@ -110,7 +113,20 @@ export function placePlayerFactionCreature(
     throw new Error('The `creatureId` does not exist on the player\'s hand.')
   }
 
+  // 配置順を記録する。
+  const maxPlacementOrder = Math.max(DEFAULT_PLACEMENT_ORDER, ...creatures.map(e => e.placementOrder))
+  const newCreatures = creatures.map(creature => {
+    if (creature.id === creatureId) {
+      return {
+        ...creature,
+        placementOrder: maxPlacementOrder + 1,
+      }
+    }
+    return creature
+  })
+
   return {
+    creatures: newCreatures,
     battleFieldMatrix: newBattleFieldMatrix,
     cardsOnPlayersHand: newCardsOnPlayersHand,
   }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -5,6 +5,7 @@ import {
   FactionId,
   Game,
   Job,
+  DEFAULT_PLACEMENT_ORDER,
   MAX_NUMBER_OF_PLAYERS_HAND,
   Party,
   createBattleFieldMatrix,
@@ -67,7 +68,7 @@ export function createCreature(): Creature {
     raidCharge: 0,
     skillIds: [],
     autoAttackInvoked: false,
-    placementOrder: 0,
+    placementOrder: DEFAULT_PLACEMENT_ORDER,
   }
 }
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -67,6 +67,7 @@ export function createCreature(): Creature {
     raidCharge: 0,
     skillIds: [],
     autoAttackInvoked: false,
+    placementOrder: 0,
   }
 }
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -12,6 +12,12 @@ import {
   determineRelationshipBetweenFactions,
   findCreatureWithParty,
 } from './utils'
+import {
+  Props as BattlePageProps,
+} from './components/pages/BattlePage'
+import {
+  Props as RootProps,
+} from './components/Root'
 
 /**
  * 整数を元にしたユニークIDを作成する関数を作成する
@@ -90,6 +96,14 @@ export function findFirstAlly(creatures: Creature[], parties: Party[], factionId
     return allies[0]
   }
   throw new Error('Can not find an ally.')
+}
+
+export function ensureBattlePageProps(props: RootProps): BattlePageProps {
+  const battlePage = props.pages.battle
+  if (battlePage === undefined) {
+    throw new Error('`props.pages.battle` does not exist.')
+  }
+  return battlePage
 }
 
 /**

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -47,6 +47,7 @@ export function createJob(): Job {
       minReach: 1,
       maxReach: 1,
     },
+    autoAttackTargets: 1,
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,7 +46,7 @@ export type Skill = {
 export type Creature = {
   _attackPowerForTest?: Job['attackPower'],
   _autoAttackRangeForTest?: Job['autoAttackRange'],
-  _autoAttackTargets?: Job['autoAttackTargets'],
+  _autoAttackTargetsForTest?: Job['autoAttackTargets'],
   _maxLifePointsForTest?: Job['maxLifePoints'],
   _raidIntervalForTest?: Job['raidInterval'],
   _raidPowerForTest?: Job['raidPower'],
@@ -569,8 +569,8 @@ export const creatureUtils = {
     return job.attackPower
   },
   getAutoAttackTargets: (creature: Creature, constants: Game['constants']): Job['autoAttackTargets'] => {
-    if (creature._autoAttackTargets !== undefined) {
-      return creature._autoAttackTargets
+    if (creature._autoAttackTargetsForTest !== undefined) {
+      return creature._autoAttackTargetsForTest
     }
     const job = findJobById(constants.jobs, creature.jobId)
     return job.autoAttackTargets

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,9 @@ export type Creature = {
   id: string,
   jobId: string,
   lifePoints: number,
+  // This value is used as the priority for auto-attacks.
+  // Creatures placed earlier have higher priority as auto-attack targets.
+  placementOrder: number,
   raidCharge: number,
   skillIds: Skill['id'][],
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,6 +30,7 @@ export type Job = {
     minReach: number,
     rangeShapeKey: string,
   },
+  autoAttackTargets: number,
   id: string,
   maxLifePoints: number,
   raidInterval: number,
@@ -45,6 +46,7 @@ export type Skill = {
 export type Creature = {
   _attackPowerForTest?: Job['attackPower'],
   _autoAttackRangeForTest?: Job['autoAttackRange'],
+  _autoAttackTargets?: Job['autoAttackTargets'],
   _maxLifePointsForTest?: Job['maxLifePoints'],
   _raidIntervalForTest?: Job['raidInterval'],
   _raidPowerForTest?: Job['raidPower'],
@@ -565,6 +567,13 @@ export const creatureUtils = {
     }
     const job = findJobById(constants.jobs, creature.jobId)
     return job.attackPower
+  },
+  getAutoAttackTargets: (creature: Creature, constants: Game['constants']): Job['autoAttackTargets'] => {
+    if (creature._autoAttackTargets !== undefined) {
+      return creature._autoAttackTargets
+    }
+    const job = findJobById(constants.jobs, creature.jobId)
+    return job.autoAttackTargets
   },
   getAutoAttackRange: (creature: Creature, constants: Game['constants']): Job['autoAttackRange'] => {
     if (creature._autoAttackRangeForTest !== undefined) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -174,6 +174,8 @@ export const ACTION_POINTS_REQUIRED_FOR_CREATURE_PLACEMENT = 2
 
 export const ACTION_POINTS_REQUIRED_FOR_SKILL_USE = 1
 
+export const DEFAULT_PLACEMENT_ORDER = 0
+
 /**
  * リーチに対しての円形の範囲を生成する。
  *

--- a/ts-node-reigister.js
+++ b/ts-node-reigister.js
@@ -1,3 +1,0 @@
-require('ts-node').register({
-  files: true,
-});


### PR DESCRIPTION
- [x] 自動攻撃範囲と対象を表示する。
  - [x] マス要素へ「範囲内か」を表現するためのオプションを作る。
  - [x] 自動攻撃範囲表示時に攻撃対象がわかるようにする。
    - [x] マス要素へ「対象か」を表現するためのオプションを作る。
    - [x] クリーチャーの配置順を記録する。
    - [x] 配置順が早い順に優先する。
    - [x] 攻撃対象数を設定できるようにし、反映する。
    - [x] 自動攻撃範囲表示時に、範囲内の対象へ、配置順から算出される優先順位を 1 から表示する。
    - [x] 攻撃対象数と優先順位を考慮した結果、自動攻撃の対象になると思われる攻撃対象については「対象か」の表示を行う。
    - [x] map-state-to-prop へテストを入れつつリファクタリングする。
    - [x] 対象かと優先順位の表示が見辛すぎるので改善する。