### PR TITLE
Remove the creature-reservation behavior

### DIFF
--- a/src/__tests__/map-state-to-props-test.ts
+++ b/src/__tests__/map-state-to-props-test.ts
@@ -110,12 +110,11 @@ describe('map-state-to-props', function() {
             assert.strictEqual(board[1][0].targetPriority, 1)
           })
 
-          it('範囲内で敵が存在していないマスは isTarget=false, targetPriority=undefined, isWithinRange=true である', function() {
+          it('範囲内で敵が存在していないマスは isTarget=false, targetPriority=undefined である', function() {
             const battlePageProps = ensureBattlePageProps(mapStateToProps(state, dummySetState))
             const board = battlePageProps.battleFieldBoard.board
             assert.strictEqual(board[1][2].isTarget, false)
             assert.strictEqual(board[1][2].targetPriority, undefined)
-            assert.strictEqual(board[1][2].isWithinRange, true)
           })
         })
       })

--- a/src/components/pages/BattlePage.tsx
+++ b/src/components/pages/BattlePage.tsx
@@ -50,7 +50,6 @@ const MetaInformationBar: React.FC<MetaInformationBarProps> = (props) => {
 export type CreatureOnElementProps = {
   factionRelationshipId: FactionRelationshipId,
   image: string,
-  isReserved: boolean,
   lifePoints: string,
   turnsUntilRaid: number,
 }
@@ -72,7 +71,6 @@ const CreatureOnElement: React.FC<CreatureOnElementProps> = (props) => {
           lineHeight: '48px',
           fontSize: '24px',
           textAlign: 'center',
-          opacity: props.isReserved ? 0.5 : 1,
         }}
       >{props.image}</div>
       {

--- a/src/map-state-to-props.ts
+++ b/src/map-state-to-props.ts
@@ -78,10 +78,7 @@ function mapBattlePageStateToProps(
   const boardProps: BattlePageProps['battleFieldBoard']['board'] = game.battleFieldMatrix.map(row => {
     return row.map(element => {
       const creatureWithParty = element.creatureId !== undefined
-        ? findCreatureWithParty(game.creatures, game.parties, element.creatureId)
-        : element.reservedCreatureId !== undefined
-          ? findCreatureWithParty(game.creatures, game.parties, element.reservedCreatureId)
-          : undefined
+        ? findCreatureWithParty(game.creatures, game.parties, element.creatureId) : undefined
       const isSelected = game.cursor
         ? areGlobalPositionsEqual(element.globalPosition, game.cursor.globalPosition)
         : false
@@ -96,7 +93,6 @@ function mapBattlePageStateToProps(
       if (creatureWithParty) {
         creatureProps = {
           image: jobIdToDummyImage(creatureWithParty.creature.jobId),
-          isReserved: element.reservedCreatureId !== undefined,
           factionRelationshipId: determineRelationshipBetweenFactions(
             'player', creatureWithParty.party.factionId),
           lifePoints: creatureWithParty.creature.lifePoints.toString(),

--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -277,17 +277,6 @@ describe('reducers/index', function() {
       battlePage = ensureBattlePage(state)
     })
 
-    it('予約中の computer 側クリーチャーの raidCharge は自然増加しない', function() {
-      const a = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'computer')
-      a._raidIntervalForTest = 1
-      a.raidCharge = 0
-      battlePage.game.battleFieldMatrix[0][0].reservedCreatureId = a.id
-      const newState = proceedTurn(runAutoAttackPhase(state))
-      const newBattlePage = ensureBattlePage(newState)
-      const newA = findCreatureById(newBattlePage.game.creatures, a.id)
-      assert.strictEqual(newA.raidCharge, 0)
-    })
-
     it('クリーチャーの自動攻撃発動済みフラグを一律 false へ更新する', function() {
       const a = findFirstAlly(battlePage.game.creatures, battlePage.game.parties, 'player')
       a.autoAttackInvoked = true

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -38,7 +38,7 @@ import {
   placePlayerFactionCreature,
   refillCardsOnPlayersHand,
   removeDeadCreatures,
-  reserveCreatures,
+  spawnCreatures,
 } from '../utils'
 
 describe('reducers/utils', function() {
@@ -449,7 +449,7 @@ describe('reducers/utils', function() {
     })
   })
 
-  describe('reserveCreatures', function() {
+  describe('spawnCreatures', function() {
     let a: Creature
     let b: Creature
     let creatures: Creature[]
@@ -469,18 +469,18 @@ describe('reducers/utils', function() {
       ]
     })
 
-    describe('出現が予約されているターン数を指定したとき', function() {
+    describe('出現が登録されているターン数を指定したとき', function() {
       const turnNumber = 2
 
-      it('クリーチャーの出現を盤へ予約する', function() {
-        const result = reserveCreatures(
+      it('クリーチャーが盤上へ出現する', function() {
+        const result = spawnCreatures(
           creatures, matrix, creatureAppearances, turnNumber, () => [matrix[0][0], matrix[0][1]])
-        assert.strictEqual(result.battleFieldMatrix[0][0].reservedCreatureId, a.id)
-        assert.strictEqual(result.battleFieldMatrix[0][1].reservedCreatureId, b.id)
+        assert.strictEqual(result.battleFieldMatrix[0][0].creatureId, a.id)
+        assert.strictEqual(result.battleFieldMatrix[0][1].creatureId, b.id)
       })
 
-      it('クリーチャーの配置順を増加する', function() {
-        const result = reserveCreatures(
+      it('出現したクリーチャーの配置順を増加する', function() {
+        const result = spawnCreatures(
           creatures, matrix, creatureAppearances, turnNumber, () => [matrix[0][0], matrix[0][1]])
         const newA = findCreatureById(result.creatures, a.id)
         const newB = findCreatureById(result.creatures, b.id)

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -55,15 +55,6 @@ describe('reducers/utils', function() {
     describe('ターン数が、computer 側クリーチャーの出現する最後のターンのとき', function() {
       const currentTurnNumber = 2
 
-      it('予約の computer 側クリーチャーが盤上に存在するとき、勝利ではない', function() {
-        const battleFieldMatrix = createBattleFieldMatrix(1, 1)
-        battleFieldMatrix[0][0].reservedCreatureId = 'a'
-        assert.strictEqual(
-          doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber),
-          false
-        )
-      })
-
       it('computer 側クリーチャーが盤上に存在するとき、勝利ではない', function() {
         const battleFieldMatrix = createBattleFieldMatrix(1, 1)
         battleFieldMatrix[0][0].creatureId = 'a'

--- a/src/reducers/__tests__/utils-test.ts
+++ b/src/reducers/__tests__/utils-test.ts
@@ -64,7 +64,7 @@ describe('reducers/utils', function() {
         )
       })
 
-      describe('予約を含む computer 側クリーチャーが盤上に存在しないとき', function() {
+      describe('computer 側クリーチャーが盤上に存在しないとき', function() {
         it('player 側クリーチャーが盤上に存在するときでも、勝利である', function() {
           const battleFieldMatrix = createBattleFieldMatrix(1, 1)
           battleFieldMatrix[0][0].creatureId = 'x'
@@ -79,7 +79,7 @@ describe('reducers/utils', function() {
     describe('ターン数が、computer 側クリーチャーの出現する最後のターン未満のとき', function() {
       const currentTurnNumber = 1
 
-      it('予約を含む computer 側クリーチャーが盤上に存在しないときでも、勝利ではない', function() {
+      it('computer 側クリーチャーが盤上に存在しないときでも、勝利ではない', function() {
         const battleFieldMatrix = createBattleFieldMatrix(1, 1)
         assert.strictEqual(
           doesPlayerHaveVictory(parties, battleFieldMatrix, creatureAppearances, currentTurnNumber),

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -324,21 +324,6 @@ export function proceedTurn(
       }))
     }
 
-    // 予約されているクリーチャーの出現が実現する。
-    const realizedCreatureAppearances: MatrixPosition[] = []
-    for (const row of draft.game.battleFieldMatrix) {
-      for (const element of row) {
-        if (element.reservedCreatureId !== undefined) {
-          realizedCreatureAppearances.push(element.position)
-        }
-      }
-    }
-    realizedCreatureAppearances.forEach(position => {
-      const element = draft.game.battleFieldMatrix[position.y][position.x]
-      element.creatureId = element.reservedCreatureId
-      element.reservedCreatureId = undefined
-    })
-
     // クリーチャーの出現を予約する。
     draft.game = {
       ...draft.game,

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -34,7 +34,7 @@ import {
   placePlayerFactionCreature,
   refillCardsOnPlayersHand,
   removeDeadCreatures,
-  reserveCreatures,
+  spawnCreatures,
 } from './utils'
 
 export function selectBattleFieldElement(
@@ -324,10 +324,10 @@ export function proceedTurn(
       }))
     }
 
-    // クリーチャーの出現を予約する。
+    // クリーチャーを出現させる。
     draft.game = {
       ...draft.game,
-      ...reserveCreatures(
+      ...spawnCreatures(
         draft.game.creatures,
         draft.game.battleFieldMatrix,
         draft.game.creatureAppearances,

--- a/src/reducers/utils.ts
+++ b/src/reducers/utils.ts
@@ -350,7 +350,7 @@ export function increaseRaidChargeForEachComputerCreatures(
   }
 }
 
-export function reserveCreatures(
+export function spawnCreatures(
   creatures: Creature[],
   battleFieldMatrix: BattleFieldMatrix,
   creatureAppearances: CreatureAppearance[],
@@ -369,15 +369,14 @@ export function reserveCreatures(
   // クリーチャーが出現するターン数のとき。
   if (creatureAppearance) {
     const elements = pickBattleFieldElementsWhereCreatureExists(battleFieldMatrix, false)
-      .filter(e => e.reservedCreatureId === undefined)
 
     // TODO: 勝敗判定に含めるなどして、この状況が発生しないようにする。
     if (elements.length < creatureAppearance.creatureIds.length) {
       throw new Error('There are no battle field elements for creature appearances.')
     }
 
-    // 出現ルールに従って、予約される位置リストを生成する。
-    const reservedCreaturePositions = choiceElements(elements, creatureAppearance.creatureIds.length)
+    // 出現ルールに従って、出現位置リストを生成する。
+    const creaturePositions = choiceElements(elements, creatureAppearance.creatureIds.length)
       .map((choicedElement, index) => {
         return {
           creatureId: creatureAppearance.creatureIds[index],
@@ -385,15 +384,12 @@ export function reserveCreatures(
         }
       })
 
-    // 各マスへクリーチャー出現を予約する。
-    // クリーチャーの配置順を更新する。
-    // NOTE: 配置順の更新を出現の実現時に行う方が良さそうだったが、この時点でないと、
-    //         同じ出現ターン内で複数のクリーチャーが存在するときの、その間の優先順位の上下がわからない。
+    // 各マスへクリーチャーを出現させる、そして、クリーチャーの配置順を更新する。
     let maxPlacementOrder = Math.max(DEFAULT_PLACEMENT_ORDER, ...newCreatures.map(e => e.placementOrder))
-    reservedCreaturePositions.forEach(({position, creatureId}) => {
+    creaturePositions.forEach(({position, creatureId}) => {
       newBattleFieldMatrix[position.y][position.x] = {
         ...newBattleFieldMatrix[position.y][position.x],
-        reservedCreatureId: creatureId,
+        creatureId: creatureId,
       }
       maxPlacementOrder++
       newCreatures = newCreatures.map(creature => {
@@ -443,10 +439,10 @@ export function initializeGame(game: Game): Game {
     }),
   }
 
-  // 1 ターン目のクリーチャーを予約する。
+  // 1 ターン目のクリーチャーを出現させる。
   newGame = {
     ...newGame,
-    ...reserveCreatures(
+    ...spawnCreatures(
       newGame.creatures,
       newGame.battleFieldMatrix,
       newGame.creatureAppearances,

--- a/src/reducers/utils.ts
+++ b/src/reducers/utils.ts
@@ -56,13 +56,8 @@ export function doesPlayerHaveVictory(
     creatureAppearances.filter(e => e.turnNumber > currentTurnNumber).length === 0 &&
     battleFieldMatrix.every(row => {
       return row.every(element => {
-        return (
-          element.reservedCreatureId === undefined &&
-          (
-            element.creatureId === undefined ||
-            findPartyByCreatureId(parties, element.creatureId).factionId === 'player'
-          )
-        )
+        return element.creatureId === undefined ||
+          findPartyByCreatureId(parties, element.creatureId).factionId === 'player'
       })
     })
   )

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -106,9 +106,6 @@ function isCardsOnPlayersHandPositionType(
 export type BattleFieldElement = {
   creatureId: Creature['id'] | undefined,
   globalPosition: GlobalPosition,
-  // Only "computer" side creatures.
-  // TODO: Either `creatureId` or `reservedCreatureId` should be an undefined.
-  reservedCreatureId: Creature['id'] | undefined,
   position: MatrixPosition,
 }
 
@@ -427,7 +424,6 @@ export function createBattleFieldMatrix(rowLength: number, columnLength: number)
           x,
         },
         creatureId: undefined,
-        reservedCreatureId: undefined,
       })
     }
     battleFieldMatrix.push(row)


### PR DESCRIPTION
- [x] 出現時にクリーチャーが予約状態になる仕様を削除する。
  - どのような効果を期待してたかというと、「プレイヤーが敵クリーチャーが行動する前に配置位置を知ることができると、運に依存する度合いが下がる。」というものだった。
  - 現在でもデバッグ中に勘違いする程度に表示上わかりにくい。
  - プログラミングも複雑になっている。特に、マスのクリーチャーの存否判定をするときにどちらかなのかどっちもなのかが、形式的にわからなくなる。
  - 代わりに「出現直後は 1 ターン行動不能」というデバフなどで表現したときと比べて、大差ない。