### PR TITLE
Give priority to the player's attack

### DIFF
--- a/src/reducers/__tests__/index-test.ts
+++ b/src/reducers/__tests__/index-test.ts
@@ -146,6 +146,31 @@ describe('reducers/index', function() {
           assert.strictEqual(newBattlePage.game.battleFieldMatrix[0][1].creatureId, undefined)
         })
       })
+
+      describe('クリーチャーそれぞれがお互いの一回の攻撃で死亡するとき', function() {
+        beforeEach(function() {
+          a.lifePoints = 1
+          a._attackPowerForTest = 1
+          b.lifePoints = 1
+          b._attackPowerForTest = 1
+        })
+
+        describe('computer 側クリーチャーが player 側クリーチャーより先に配置されているとき', function() {
+          beforeEach(function() {
+            a.placementOrder = 2
+            b.placementOrder = 1
+          })
+
+          it('player 側クリーチャーの攻撃が先行するため computer 側クリーチャーが死亡し、player 側は無傷である', function() {
+            const newState = runAutoAttackPhase(state)
+            const newBattlePage = ensureBattlePage(newState)
+            const newA = findCreatureById(newBattlePage.game.creatures, a.id)
+            const newB = findCreatureById(newBattlePage.game.creatures, b.id)
+            assert.strictEqual(newA.lifePoints, 1)
+            assert.strictEqual(newB.lifePoints, 0)
+          })
+        })
+      })
     })
 
     describe('味方関係であるクリーチャーが隣接しているとき', function() {

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -34,6 +34,7 @@ import {
   placePlayerFactionCreature,
   refillCardsOnPlayersHand,
   removeDeadCreatures,
+  sortAutoAttackersOrder,
   spawnCreatures,
 } from './utils'
 
@@ -217,7 +218,7 @@ export function runAutoAttackPhase(
     // 攻撃者リストを抽出する。
     const elementsWhereCreatureExists =
       pickBattleFieldElementsWhereCreatureExists(game.battleFieldMatrix)
-    const attackerDataList: CreatureWithPartyOnBattleFieldElement[] = elementsWhereCreatureExists
+    let attackerDataList: CreatureWithPartyOnBattleFieldElement[] = elementsWhereCreatureExists
       .map((battleFieldElement) => {
         // NOTE: pickBattleFieldElementsWhereCreatureExists で creatureId が存在していることを保証している。
         const creatureId = battleFieldElement.creatureId as Creature['id']
@@ -227,7 +228,8 @@ export function runAutoAttackPhase(
         )
       })
 
-    // TODO: 攻撃者リストを発動順に整列する。
+    // 攻撃者リストを発動順に整列する。
+    attackerDataList = sortAutoAttackersOrder(attackerDataList)
 
     let gameBeingUpdated = {...game}
 

--- a/src/reducers/utils.ts
+++ b/src/reducers/utils.ts
@@ -175,6 +175,34 @@ export function removeDeadCreatures(
   }
 }
 
+/**
+ * 自動攻撃の攻撃者リストを発動順で整列する。
+ */
+export function sortAutoAttackersOrder(
+  attackers: CreatureWithPartyOnBattleFieldElement[],
+): CreatureWithPartyOnBattleFieldElement[] {
+  return attackers
+    .slice()
+    // 第 2 条件は、クリーチャーの配置順である。
+    .sort((a, b) => {
+      if (a.creature.placementOrder < b.creature.placementOrder) {
+        return -1
+      } else if (a.creature.placementOrder > b.creature.placementOrder) {
+        return 1
+      }
+      return 0
+    })
+    // 第 1 条件は、player 側かどうかである。
+    .sort((a, b) => {
+      if (a.party.factionId === 'player' && b.party.factionId === 'computer') {
+        return -1
+      } else if (a.party.factionId === 'computer' && b.party.factionId === 'player') {
+        return 1
+      }
+      return 0
+    })
+}
+
 export function invokeAutoAttack(
   constants: Game['constants'],
   creatures: Creature[],


### PR DESCRIPTION
- [x] 自動攻撃の攻撃順を正しく整列する。
  - [x] 第 1 条件は、player 側であること。
  - [x] 第 2 条件は、配置順の昇順。